### PR TITLE
Factor out _manifest parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,20 @@
 prefix = /usr
-PYTHON ?= python
+PYTHON ?= python3
 
 servicedir = ${prefix}/lib/obs/service
 
-all:
+all: build
 
-install:
-	install -d $(DESTDIR)$(servicedir)
-	install -m 0755 obs_scm_bridge $(DESTDIR)$(servicedir)
-
-test:
-	flake8 set_version tests/
-	${PYTHON} -m unittest discover tests/
+build:
+	echo '#!/usr/bin/python3' > obs_scm_bridge.py
+	cat obs_scm_bridge/manifest.py >> obs_scm_bridge.py
+	echo '' >> obs_scm_bridge.py
+	cat obs_scm_bridge/__main__.py >> obs_scm_bridge.py
+	chmod +x obs_scm_bridge.py
 
 clean:
 	find -name "*.pyc" -exec rm {} \;
 	find -name '*.pyo' -exec rm {} \;
-	rm -rf set_versionc
+	rm -f obs_scm_bridge.py
 
-.PHONY: all install test
+.PHONY: all build clean

--- a/README.md
+++ b/README.md
@@ -106,6 +106,36 @@ These configuration files are optional and usually only used on OBS server side.
   PROJECT\_NAMESPACE is also valid for all sub projects. When using '*' it is
   valid for all projects.
 
+Python module usecase
+=====================
+
+We provide a python module to parse the structure of a cloned project git
+repository. 
+
+The method
+
+  list_packages(directory: str) -> List[Tuple[str, str, Optional[str]]]
+
+is parsing the _manifest file and reads the .gitsubmodule file. It gives 
+you a tuple for each package source providing:
+
+ * package name
+
+   As it appears in OBS. It is not including build flavors.
+
+ * relative directory name
+
+   Depending on the configuration this can be in any subdirectory.
+   In default configuration it would be identical to package name.
+
+ * Git submodule path
+   
+   This might be a relative path or absolute url to another git
+   repository providing the package source. In SUSE cases this
+   is often just ../pool/REPOSITORY_NAME for example. Please note
+   that PACKAGE_NAME and REPOSITORY_NAME is often the same, but
+   not guaranteed.
+
 
 TODO
 ====
@@ -115,6 +145,4 @@ TODO
  * find a better way to store files in .osc and .assets of the checkout, as
    they do not belong to the git repository
     auto extending .gitignore? (esp. when downloading asset files?)
-
- * make cpio generation bit identical (avoiding mtime from clone)
 

--- a/examples/list_packages.py
+++ b/examples/list_packages.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+# Example application to parse a local git repository using list_packages
+
+import argparse
+import logging
+import os
+import sys
+
+import obs_scm_bridge
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Parse a local git repository and list packages'
+    )
+    parser.add_argument(
+        'directory',
+        help='Path to the git repository',
+        nargs='?',
+        default='.'
+    )
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Enable debug logging'
+    )
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    if not os.path.isdir(args.directory):
+        print(f"Error: '{args.directory}' is not a directory")
+        sys.exit(1)
+
+    if not os.path.isdir(os.path.join(args.directory, '.git')):
+        print(f"Warning: '{args.directory}' does not appear to be a git repository")
+
+    packages = obs_scm_bridge.list_packages(args.directory)
+
+    print(f"Found {len(packages)} entries in '{args.directory}':\n")
+    print(f"{'Package':<30} {'Subdir':<30} {'Submodule URL'}")
+    print("-" * 80)
+
+    for pkg, subdir, submod in packages:
+        print(f"{pkg:<30} {subdir:<30} {submod or '-'}")
+
+
+if __name__ == '__main__':
+    main()

--- a/obs_scm_bridge.py
+++ b/obs_scm_bridge.py
@@ -1,4 +1,225 @@
 #!/usr/bin/python3
+import logging
+import os
+import re
+import yaml
+import configparser
+from typing import Dict, List, Optional, Tuple
+
+
+def read_project_manifest(filename: str) -> Tuple[Optional[List[str]], List[str]]:
+    packages = None
+    subdirectories = []
+    manifest_yml = None
+    with open(filename) as stream:
+        manifest_yml = yaml.safe_load(stream)
+    if 'packages' in manifest_yml:
+        packages = []
+    if manifest_yml.get('packages'):
+        for name in manifest_yml['packages']:
+            if not name or name.startswith('.') or name.startswith('/'):
+                logging.warn("illegal packages entry '%s'", name)
+                continue
+            if '/' in name or '*' in name:
+                logging.warn("packages entry with '/' or '*' not implemented yet")
+                continue
+            packages.append(name)
+    if manifest_yml.get('subdirectories'):
+        for newsubdir in manifest_yml['subdirectories']:
+            if newsubdir:
+                subdirectories.append(newsubdir)
+    return packages, subdirectories
+
+### Legacy, don't use this anymore
+def read_project_subdirs(filename: str) -> Tuple[Optional[List[str]], List[str]]:
+    packages = None
+    subdirectories = []
+    subdir_yml = None
+    with open(filename) as stream:
+        subdir_yml = yaml.safe_load(stream)
+    for newsubdir in subdir_yml['subdirs']:
+        if newsubdir:
+            subdirectories.append(newsubdir)
+    if 'toplevel' not in subdir_yml or subdir_yml['toplevel'] != 'include':
+        packages = []
+    return packages, subdirectories
+
+
+_REGEXP = re.compile(r"^[a-zA-Z0-9\-\_\+][a-zA-Z0-9\.\-\_\+]*$")
+
+
+def _read_gitmodules(directory: str) -> Dict[str, Tuple[str, str]]:
+    submodule_paths = {}
+    gitmodules_path = os.path.join(directory, '.gitmodules')
+    if not os.path.isfile(gitmodules_path):
+        return submodule_paths
+    
+    gsmconfig = configparser.ConfigParser()
+    gitmodules = None
+    with open(gitmodules_path) as f:
+        gitmodules = f.read()
+    gitmodules = "\n".join([line.lstrip() for line in gitmodules.split("\n")])
+    gsmconfig.read_string(gitmodules)
+    for section in gsmconfig.sections():
+        gsm = gsmconfig[section]
+        if 'path' in gsm:
+            submodule_paths[gsm['path']] = (section, gsm.get('url', ''))
+    return submodule_paths
+
+
+def list_packages(directory: str) -> List[Tuple[str, str, Optional[str]]]:
+    results = []
+    seen = set()
+
+    if not os.path.isdir(directory):
+        return results
+
+    submodule_paths = _read_gitmodules(directory)
+
+    if os.path.isfile(directory + '/_manifest'):
+        (_packages, _subdirs) = read_project_manifest(directory + '/_manifest')
+        if _packages:
+            for pkg in _packages:
+                if not pkg or pkg.startswith('.'):
+                    logging.warn("illegal packages entry '%s'", pkg)
+                    continue
+                if pkg in seen:
+                    logging.debug("duplicate package entry '%s'", pkg)
+                    continue
+                seen.add(pkg)
+                if '/' in pkg:
+                    subdir = pkg
+                    pkg_name = pkg.rsplit('/', 1)[-1]
+                    results.append((pkg_name, subdir, None))
+                else:
+                    results.append((pkg, pkg, None))
+        if _subdirs:
+            for subdir in _subdirs:
+                if not subdir:
+                    continue
+                if subdir in seen:
+                    logging.debug("duplicate subdirectory entry '%s'", subdir)
+                    continue
+                seen.add(subdir)
+
+                subdir_path = os.path.join(directory, subdir)
+                if os.path.isdir(subdir_path):
+                    for entry in os.listdir(subdir_path):
+                        entry_path = os.path.join(subdir_path, entry)
+                        if not os.path.isdir(entry_path):
+                            continue
+                        if not _REGEXP.match(entry):
+                            continue
+                        if entry in seen:
+                            logging.debug("duplicate package entry '%s'", entry)
+                            continue
+                        seen.add(entry)
+                        full_subdir = subdir + '/' + entry
+                        submod_info = submodule_paths.get(full_subdir)
+                        submod_url = submod_info[1] if submod_info else None
+                        results.append((entry, full_subdir, submod_url))
+                else:
+                    submod_info = submodule_paths.get(subdir)
+                    submod_url = submod_info[1] if submod_info else None
+                    results.append((subdir, subdir, submod_url))
+        return results
+
+    ### legacy, might get dropped
+    if os.path.isfile(directory + '/_subdirs'):
+        (_packages, _subdirs) = read_project_subdirs(directory + '/_subdirs')
+        if _packages:
+            for pkg in _packages:
+                if not pkg or pkg.startswith('.'):
+                    logging.warn("illegal packages entry '%s'", pkg)
+                    continue
+                if pkg in seen:
+                    logging.debug("duplicate package entry '%s'", pkg)
+                    continue
+                seen.add(pkg)
+                if '/' in pkg:
+                    subdir = pkg
+                    pkg_name = pkg.rsplit('/', 1)[-1]
+                    results.append((pkg_name, subdir, None))
+                else:
+                    results.append((pkg, pkg, None))
+        if _subdirs:
+            for subdir in _subdirs:
+                if not subdir:
+                    continue
+                if subdir in seen:
+                    logging.debug("duplicate subdirectory entry '%s'", subdir)
+                    continue
+                seen.add(subdir)
+
+                subdir_path = os.path.join(directory, subdir)
+                if os.path.isdir(subdir_path):
+                    for entry in os.listdir(subdir_path):
+                        entry_path = os.path.join(subdir_path, entry)
+                        if not os.path.isdir(entry_path):
+                            continue
+                        if not _REGEXP.match(entry):
+                            continue
+                        if entry in seen:
+                            logging.debug("duplicate package entry '%s'", entry)
+                            continue
+                        seen.add(entry)
+                        full_subdir = subdir + '/' + entry
+                        submod_info = submodule_paths.get(full_subdir)
+                        submod_url = submod_info[1] if submod_info else None
+                        results.append((entry, full_subdir, submod_url))
+                else:
+                    submod_info = submodule_paths.get(subdir)
+                    submod_url = submod_info[1] if submod_info else None
+                    results.append((subdir, subdir, submod_url))
+        return results
+
+    package_names = []
+    subdirectory_names = []
+    for entry in os.listdir(directory):
+        if entry.startswith('.') or entry.startswith('/'):
+            continue
+        if not _REGEXP.match(entry):
+            continue
+        full_path = os.path.join(directory, entry)
+        if os.path.isdir(full_path):
+            subdirectory_names.append(entry)
+        elif os.path.isfile(full_path):
+            package_names.append(entry)
+
+    for pkg in package_names:
+        if pkg in seen:
+            logging.debug("duplicate package entry '%s'", pkg)
+            continue
+        seen.add(pkg)
+        results.append((pkg, pkg, None))
+    for subdir in subdirectory_names:
+        if subdir in seen:
+            logging.debug("duplicate subdirectory entry '%s'", subdir)
+            continue
+        seen.add(subdir)
+        submod_info = submodule_paths.get(subdir)
+        submod_url = submod_info[1] if submod_info else None
+        results.append((subdir, subdir, submod_url))
+
+    for submod_path in submodule_paths.keys():
+        if submod_path in seen:
+            logging.debug("duplicate submodule entry '%s'", submod_path)
+            continue
+        seen.add(submod_path)
+        submod_info = submodule_paths.get(submod_path)
+        submod_url = submod_info[1] if submod_info else None
+        results.append((submod_path, submod_path, submod_url))
+
+    validated_results = []
+    for pkg, subdir, submod in results:
+        if not pkg and not subdir:
+            logging.warn("entry has empty package_name and git_subdirectory")
+            continue
+        validated_results.append((pkg, subdir, submod))
+
+    return validated_results
+
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 
 # scm (only git atm) cloning and packaging for Open Build Service
@@ -19,11 +240,12 @@ import sys
 import logging
 import subprocess
 import tempfile
-import yaml
 from html import escape
 from typing import Dict, List, Optional, TextIO, Tuple, Union
 import urllib.parse
 import configparser
+
+from obs_scm_bridge.manifest import read_project_manifest, read_project_subdirs
 
 download_assets = '/usr/lib/build/download_assets'
 critical_instances_config = "/etc/obs/services/scm-bridge/critical-instances"
@@ -72,17 +294,15 @@ class ObsGit(object):
         self.url = list(urllib.parse.urlparse(url))
         self.no_lfs = False
         self.enforce_bcntsynctag = False
-        # for project level mode
         self.processed = {}
         self.git_store = None
         self.shallow_clone = shallow_clone
         self.create_obsinfo = create_obsinfo
         self.add_noobsinfo = False
-        #: git submodule config, if present
         self.gsmconfig: Optional[configparser.ConfigParser] = None
         self.gsmpath = {}
         self.gsmrevisions = {}
-        self.asset_types_filter = [] # all by default
+        self.asset_types_filter = []
 
         query = urllib.parse.parse_qs(self.url[4], keep_blank_values=True)
         if "subdir" in query:
@@ -127,30 +347,16 @@ class ObsGit(object):
         if self.url[5]:
             self.revision = self.url[5]
             self.url[5] = ''
-        # we cannot keep the meta in subdir mode and we can always
-        # do a shallow clone
         if self.subdir:
             self.shallow_clone = True
-            # we cannot do a shallow clone if we want the commit data
-            # for a specific directory
             if self.create_obsinfo and write_obsinfo_with_subdir:
                 self.shallow_clone = False
             self.keep_meta = False
-        # if we keep the meta files we always want a deep clone
         if self.keep_meta:
             self.shallow_clone = False
-        # scmtoolurl is the url we pass to the the scm tool
         scmtoolurl = self.url.copy()
         if scmtoolurl[0] and scmtoolurl[0][0:4] == 'git+':
             scmtoolurl[0] = scmtoolurl[0][4:]
-        # we want to switch to ssh as the user is likely providing his
-        # access via ssh pub key already.
-        # Unfortunality there is no generic way to rewrite the url as
-        # it depends on the installation.
-        # For now we hard code our instances, but this needs to become
-        # configurable or we need to detect it by asking the server
-        # somehow.
-        # Expect this to be moved to a config file
         if rewrite_url_to_ssh and scmtoolurl[0] == 'https':
             if scmtoolurl[1] == 'src.suse.de':
                 scmtoolurl[1] = 'gitea@src.suse.de'
@@ -164,16 +370,10 @@ class ObsGit(object):
         logging.error(msg)
         sys.exit(1)
 
-    def add_critical_instance(
-            self,
-            name: str
-    ) -> None:
+    def add_critical_instance(self, name: str) -> None:
         self.critical_git_servers.append(name)
 
-    def setup_credentials(
-            self,
-            cred_file: str
-    ) -> None:
+    def setup_credentials(self, cred_file: str) -> None:
         self.git_store = tempfile.mkstemp(prefix="obs-scm-bridge-git-cred-store", text=True)
         cmd = [ 'git', 'config', '--global', 'credential.helper', f"store --file {self.git_store[1]}" ]
         self.run_cmd(cmd, fatal="git config credential.helper")
@@ -190,49 +390,25 @@ class ObsGit(object):
                     continue
 
                 cmd = [ 'git', 'credential-store', '--file', self.git_store[1], 'store' ]
-                proc = subprocess.Popen(cmd,
-                                        shell=False,
-                                        encoding="utf-8",
-                                        stdin=subprocess.PIPE)
-                # hostname username token/password
+                proc = subprocess.Popen(cmd, shell=False, encoding="utf-8", stdin=subprocess.PIPE)
                 text=f"protocol=https\nhost={entry[1]}\nusername={entry[2]}\npassword={entry[3]}\n"
                 proc.communicate(input=text)
                 if proc.returncode != 0:
                     self.die("could not setup git credential store")
 
-    def run_cmd_nonfatal(
-            self,
-            cmd: List[str],
-            *,
-            cwd: Optional[str]=None,
-            stdout: Union[int, TextIO]=subprocess.PIPE,
-            env: Optional[Dict[str, str]]=None,
-    ) -> Tuple[int, str]:
+    def run_cmd_nonfatal(self, cmd: List[str], *, cwd: Optional[str]=None, stdout: Union[int, TextIO]=subprocess.PIPE, env: Optional[Dict[str, str]]=None) -> Tuple[int, str]:
         logging.debug("COMMAND: %s" % cmd)
         stderr = subprocess.PIPE
         if stdout == subprocess.PIPE:
             stderr = subprocess.STDOUT
-        proc = subprocess.Popen(cmd,
-                                shell=False,
-                                stdout=stdout,
-                                stderr=stderr,
-                                cwd=cwd,
-                                env=env)
+        proc = subprocess.Popen(cmd, shell=False, stdout=stdout, stderr=stderr, cwd=cwd, env=env)
         std_out = proc.communicate()[0]
         output = std_out.decode() if std_out else ''
 
         logging.debug("RESULT(%d): %s", proc.returncode, repr(output))
         return (proc.returncode, output)
 
-    def run_cmd(
-            self,
-            cmd: List[str],
-            *,
-            fatal: str,
-            cwd: Optional[str]=None,
-            stdout: Union[int, TextIO]=subprocess.PIPE,
-            env: Optional[Dict[str, str]]=None,
-    ) -> str:
+    def run_cmd(self, cmd: List[str], *, fatal: str, cwd: Optional[str]=None, stdout: Union[int, TextIO]=subprocess.PIPE, env: Optional[Dict[str, str]]=None) -> str:
         returncode, output = self.run_cmd_nonfatal(cmd, cwd=cwd, stdout=stdout, env=env)
         if returncode != 0:
             print("ERROR: " + fatal + " failed: ", output)
@@ -282,18 +458,13 @@ class ObsGit(object):
     def do_clone_commit(self, outdir: str, include_submodules: bool=False) -> None:
         assert self.revision, "no revision is set but do_clone_commit was called"
         objectformat='--object-format=sha1'
-        # we don't check for trailing zeros here on purpose. This blocks the usage
-        # of SHA1 package git in a SHA256 git project. If this is needed, we may
-        # implement a switch for that.
         if len(self.revision) == 64:
             objectformat='--object-format=sha256'
         else:
-            # Detect SHA type of the server
-            # We need to do this to support different type of SHA-256 submodule in a SHA-1 git repo
             cmd = [ 'git', 'ls-remote', self.scmtoolurl, 'HEAD' ]
             output = self.run_cmd(cmd, fatal="git ls-remote")
             lastline = output.splitlines()[-1]
-            if len(lastline.rstrip()) == 69: # SHA-256 plus \t plus HEAD
+            if len(lastline.rstrip()) == 69:
                 objectformat='--object-format=sha256'
         cmd = [ 'git', 'init', objectformat, outdir ]
         self.run_cmd(cmd, fatal="git init")
@@ -308,8 +479,6 @@ class ObsGit(object):
             cmd += [ '--recurse-submodules' ]
         (returncode, output) = self.run_cmd_nonfatal(cmd)
         if returncode != 0:
-            # fetch failed, maybe the server refuses to give out unadvertised commits.
-            # fall back to a a full fetch
             cmd = [ 'git', '-C', outdir, 'fetch', 'origin' ]
             if include_submodules:
                 cmd += [ '--recurse-submodules' ]
@@ -317,7 +486,6 @@ class ObsGit(object):
         if self.subdir:
             self.do_set_sparse_checkout(outdir)
         self.do_checkout(outdir, self.revision, include_submodules=include_submodules)
-
 
     def is_type_enabled(self, asset_type: str):
         if not self.asset_types_filter:
@@ -349,8 +517,6 @@ class ObsGit(object):
                 cmd += [ "--recurse-submodules=" + self.subdir ]
             else:
                 cmd += [ '--recurse-submodules' ]
-            # git submodule cloning may fail if we shallow clone
-            # do_shallow_clone = False
         if do_shallow_clone:
             cmd += [ '--depth', '1' ]
         if self.subdir:
@@ -370,11 +536,8 @@ class ObsGit(object):
         if self.subdir or reset_to_commit:
             self.do_checkout(outdir, 'HEAD', include_submodules=include_submodules)
 
-    # the _scmsync.obsinfo file might become obsolete again when we store entire
-    # git history by default later.
     def write_obsinfo(self) -> None:
         if not self.create_obsinfo:
-            # we write it only when importing data into the source server
             return
         if not self.subdir:
             cmd = [ 'git', 'rev-parse', 'HEAD' ]
@@ -392,12 +555,10 @@ class ObsGit(object):
             self.die("the _scmsync.obsinfo file must not be part of the git repository")
         with open(infofile, 'x') as obsinfo:
             obsinfo.write("mtime: " + tstamp + "\n")
-            # commit is the resulting commit hash
             obsinfo.write("commit: " + commit + "\n")
             if self.scmtoolurl:
                 obsinfo.write("url: " + self.scmtoolurl + "\n")
             if self.revision:
-                # revision can be the required commit, tag or branch requested.
                 obsinfo.write("revision: " + self.revision + "\n")
             if self.trackingbranch:
                 obsinfo.write("trackingbranch: " + self.trackingbranch + "\n")
@@ -430,10 +591,9 @@ class ObsGit(object):
         if os.path.islink(fromdir):
             if no_local_link:
                 self.die(f"local link points to another local link: {self.subdir}")
-            target = os.readlink(fromdir).rstrip('/') # this is no recursive lookup, but is there a usecase?
+            target = os.readlink(fromdir).rstrip('/')
             if not target or '/' in target or target.startswith('.'):
                 self.die(f"only local links are supported: {self.subdir}")
-            # switch subdir and clone again
             self.subdir=target
             shutil.rmtree(clonedir)
             self.clonedir = None
@@ -479,7 +639,6 @@ class ObsGit(object):
         specials = []
         for name in listing:
             if name in ('.git', '.gitattributes') and not self.keep_meta:
-                # we do not store git meta data by default to avoid bloat storage
                 continue
             if name[0:1] == '.':
                 specials.append(name)
@@ -487,13 +646,8 @@ class ObsGit(object):
             if os.path.islink(name):
                 specials.append(name)
                 continue
-            # FIXME: better way would be to store all permission flags git stores
-            #        and re-apply them without moving them.
             if os.path.isfile(name) and os.access(name, os.X_OK):
                 specials.append(name)
-                # we package it twice as eg. executable spec files need still be available
-                # for the source server
-                ### continue
             if os.path.isdir(name):
                 logging.info("CPIO %s ", name)
                 self.cpio_directory(name)
@@ -532,7 +686,6 @@ class ObsGit(object):
 
     def get_debian_origtar(self) -> None:
         if os.path.isfile(self.outdir + "/debian/control"):
-            # need up get all tags 
             if not self.subdir:
                 self.fetch_tags()
             cmd = [ export_debian_orig_from_git, self.outdir ]
@@ -627,7 +780,6 @@ class ObsGit(object):
         if not revision:
             self.die(f"could not determine revision of submodule for {gsmsection['path']}")
 
-        # write xml file and register the module
         url = list(urllib.parse.urlparse(urlstr))
         url[5] = revision
         if 'branch' in gsmsection:
@@ -647,12 +799,8 @@ class ObsGit(object):
             query['noobsinfo'] = [ '1' ]
             url[4] = urllib.parse.urlencode(query, doseq=True)
 
-        # handle relative urls in submodules
         unparsed_url = urllib.parse.urlunparse(url)
         if ".." == unparsed_url[0:2]:
-            # need to append a '/' to the base url so that the relative
-            # path is properly resolved, otherwise we might descend one
-            # directory too far
             unparsed_url = urllib.parse.urljoin(self.scmtoolurl+'/', unparsed_url)
         if self.url[0][0:4] == 'git+':
             unparsed_url = 'git+' + unparsed_url
@@ -663,16 +811,13 @@ class ObsGit(object):
         self.write_info_file(name + ".info", revision)
 
     def process_package_subdirectory(self, name: str, subdir: str) -> None:
-        # current directory is self.outdir
         if not self._REGEXP.match(name):
             logging.warn("directory name contains invalid char: %s", name)
             return
 
-        # add subdir info file
         info = self.get_subdir_info(subdir + name)
         self.write_info_file(name + ".info", info)
 
-        # add subdir parameter to url
         url = self.url.copy()
         query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
         query['subdir'] = subdir + name
@@ -706,8 +851,6 @@ class ObsGit(object):
     def parse_gsmconfig(self):
         self.gsmconfig = configparser.ConfigParser()
 
-        # the parser stumbles over a mix of space and tabs. So, let's strip
-        # leading whitespaces first
         gitmodules = None
         with open(self.clonedir + '/.gitmodules') as f:
             gitmodules = f.read()
@@ -745,42 +888,6 @@ class ObsGit(object):
         shutil.rmtree(clonedir)
         self.clonedir = None
 
-    def read_project_manifest(self, filename):
-        packages = None
-        subdirectories = []
-        manifest_yml = None
-        with open(filename) as stream:
-            manifest_yml = yaml.safe_load(stream)
-        if 'packages' in manifest_yml:
-            packages = []
-        if manifest_yml.get('packages'):
-            for name in manifest_yml['packages']:
-                if not name or name.startswith('.') or name.startswith('/'):
-                    logging.warn("illegal packages entry '%s'", name)
-                    continue
-                if '/' in name or '*' in name: # for now
-                    logging.warn("packages entry with '/' or '*' not implemented yet")
-                    continue
-                packages.append(name)
-        if manifest_yml.get('subdirectories'):
-            for newsubdir in manifest_yml['subdirectories']:
-                if newsubdir:
-                    subdirectories.append(newsubdir)
-        return packages, subdirectories
-
-    def read_project_subdirs(self, filename):
-        packages = None
-        subdirectories = []
-        subdir_yml = None
-        with open(filename) as stream:
-            subdir_yml = yaml.safe_load(stream)
-        for newsubdir in subdir_yml['subdirs']:
-            if newsubdir:
-                subdirectories.append(newsubdir)
-        if 'toplevel' not in subdir_yml or subdir_yml['toplevel'] != 'include':
-            packages = []
-        return packages, subdirectories
-
     def generate_package_xml_files_of_directory(self, subdir) -> None:
         if subdir:
             self.verify_subdir(subdir)
@@ -796,11 +903,10 @@ class ObsGit(object):
         subdirectories = []
 
         if os.path.isfile(directory + '/_manifest'):
-            (packages, subdirectories) = self.read_project_manifest(directory + '/_manifest')
+            (packages, subdirectories) = read_project_manifest(directory + '/_manifest')
         elif os.path.isfile(directory + '/_subdirs'):
-            (packages, subdirectories) = self.read_project_subdirs(directory + '/_subdirs')
+            (packages, subdirectories) = read_project_subdirs(directory + '/_subdirs')
 
-        # handle all subdirectories
         for newsubdir in subdirectories:
             if (subdir + newsubdir + '/') in self.processed:
                 continue
@@ -811,17 +917,16 @@ class ObsGit(object):
             logging.debug("walk via %s", directory)
             packages = sorted(os.listdir(directory))
 
-        # handle plain files and directories
         for name in packages:
             if name in self.processed:
-                continue                # already handled
+                continue
             fname = directory + '/' + name
             if name == '.git':
                 if self.keep_meta and subdir == '':
                     shutil.move(fname, '.')
                     self.processed[name] = True
             elif os.path.islink(fname):
-                target = os.readlink(fname).rstrip('/') # this is no recursive lookup, but is there a usecase?
+                target = os.readlink(fname).rstrip('/')
                 if not target or '/' in target or target.startswith('.'):
                     logging.warn("only local links are supported, skipping: %s -> %s", name, target)
                     continue
@@ -832,7 +937,7 @@ class ObsGit(object):
                 self.processed[name] = True
             elif os.path.isdir(fname):
                 if (subdir + name + '/') in self.processed:
-                    continue            # already handled in _subdir loop
+                    continue
                 if (subdir + name) in self.gsmpath:
                     self.process_package_submodule(name, subdir)
                 else:
@@ -870,7 +975,6 @@ if __name__ == '__main__':
         logging.getLogger().setLevel(logging.DEBUG)
         logging.debug("Running in debug mode")
 
-    # workflow
     obsgit = ObsGit(outdir, url, projectscmsync)
     obsgit.add_critical_instance("src.opensuse.org")
     if os.path.isfile(critical_instances_config):
@@ -894,4 +998,3 @@ if __name__ == '__main__':
         if obsgit.is_type_enabled('dsc'):
             obsgit.export_debian_files()
         obsgit.cpio_directories()
-

--- a/obs_scm_bridge/__init__.py
+++ b/obs_scm_bridge/__init__.py
@@ -1,0 +1,3 @@
+from obs_scm_bridge.manifest import read_project_manifest, read_project_subdirs, list_packages
+
+__version__ = "0.7.4"

--- a/obs_scm_bridge/__main__.py
+++ b/obs_scm_bridge/__main__.py
@@ -1,0 +1,779 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+# scm (only git atm) cloning and packaging for Open Build Service
+# 
+# (C) 2021 by Adrian Schröter <adrian@suse.de>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+# See http://www.gnu.org/licenses/gpl-2.0.html for full license text.
+
+import argparse
+import os
+import re
+import shutil
+import sys
+import logging
+import subprocess
+import tempfile
+from html import escape
+from typing import Dict, List, Optional, TextIO, Tuple, Union
+import urllib.parse
+import configparser
+
+from obs_scm_bridge.manifest import read_project_manifest, read_project_subdirs
+
+download_assets = '/usr/lib/build/download_assets'
+critical_instances_config = "/etc/obs/services/scm-bridge/critical-instances"
+credentials_config = "/etc/obs/services/scm-bridge/credentials"
+export_debian_orig_from_git = '/usr/lib/build/export_debian_orig_from_git'
+pack_directories = False
+follow_tracking_branch = False
+get_assets = False
+shallow_clone = True
+create_obsinfo = False
+rewrite_url_to_ssh = False
+write_obsinfo_with_subdir = True
+testcase_mode = False
+
+if os.environ.get('DEBUG_SCM_BRIDGE') == "1":
+    logging.getLogger().setLevel(logging.DEBUG)
+if os.environ.get('SCM_BRIDGE_TESTCASE') == "1":
+    testcase_mode = True
+if os.environ.get('OBS_SERVICE_DAEMON'):
+    pack_directories = True
+    get_assets = True
+    create_obsinfo = True
+if os.environ.get('OSC_VERSION'):
+    get_assets = True
+    shallow_clone = False
+    create_obsinfo = False
+    rewrite_url_to_ssh = True
+    follow_tracking_branch = True
+os.environ['LANG'] = "C"
+
+class ObsGit(object):
+
+    _REGEXP = re.compile(r"^[a-zA-Z0-9\-\_\+][a-zA-Z0-9\.\-\_\+]*$")
+
+    def __init__(self, outdir: str, url: str, projectscmsync: str) -> None:
+        self.outdir   = outdir
+        self.clonedir = None
+        self.revision = None
+        self.trackingbranch = None
+        self.subdir   = None
+        self.projectscmsync = projectscmsync
+        self.keep_meta = False
+        self.arch = []
+        self.critical_git_servers = []
+        self.onlybuild = None
+        self.url = list(urllib.parse.urlparse(url))
+        self.no_lfs = False
+        self.enforce_bcntsynctag = False
+        self.processed = {}
+        self.git_store = None
+        self.shallow_clone = shallow_clone
+        self.create_obsinfo = create_obsinfo
+        self.add_noobsinfo = False
+        self.gsmconfig: Optional[configparser.ConfigParser] = None
+        self.gsmpath = {}
+        self.gsmrevisions = {}
+        self.asset_types_filter = []
+
+        query = urllib.parse.parse_qs(self.url[4], keep_blank_values=True)
+        if "subdir" in query:
+            self.subdir = query['subdir'][0]
+            del query['subdir']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "arch" in query:
+            self.arch = query['arch']
+            del query['arch']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "enforce_bcntsynctag" in query:
+            self.enforce_bcntsynctag = True
+            del query['enforce_bcntsynctag']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "keepmeta" in query:
+            self.keep_meta = True
+            del query['keepmeta']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "lfs" in query:
+            self.no_lfs = query["lfs"] == ["0"]
+            del query["lfs"]
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "onlybuild" in query:
+            ob = query['onlybuild']
+            self.onlybuild={ob[i]:1 for i in range(len(ob))}
+            del query['onlybuild']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "noobsinfo" in query:
+            self.add_noobsinfo = True
+            self.create_obsinfo = False
+            del query['noobsinfo']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if 'trackingbranch' in query:
+            self.trackingbranch = query['trackingbranch'][0]
+            del query['trackingbranch']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "buildtype" in query:
+            t = query['buildtype']
+            self.asset_types_filter=[t[i] for i in range(len(t))]
+            del query['buildtype']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.url[5]:
+            self.revision = self.url[5]
+            self.url[5] = ''
+        if self.subdir:
+            self.shallow_clone = True
+            if self.create_obsinfo and write_obsinfo_with_subdir:
+                self.shallow_clone = False
+            self.keep_meta = False
+        if self.keep_meta:
+            self.shallow_clone = False
+        scmtoolurl = self.url.copy()
+        if scmtoolurl[0] and scmtoolurl[0][0:4] == 'git+':
+            scmtoolurl[0] = scmtoolurl[0][4:]
+        if rewrite_url_to_ssh and scmtoolurl[0] == 'https':
+            if scmtoolurl[1] == 'src.suse.de':
+                scmtoolurl[1] = 'gitea@src.suse.de'
+                scmtoolurl[0] = 'ssh'
+            elif scmtoolurl[1] == 'src.opensuse.org':
+                scmtoolurl[1] = 'gitea@src.opensuse.org'
+                scmtoolurl[0] = 'ssh'
+        self.scmtoolurl = urllib.parse.urlunparse(scmtoolurl)
+
+    def die(self, msg:str):
+        logging.error(msg)
+        sys.exit(1)
+
+    def add_critical_instance(self, name: str) -> None:
+        self.critical_git_servers.append(name)
+
+    def setup_credentials(self, cred_file: str) -> None:
+        self.git_store = tempfile.mkstemp(prefix="obs-scm-bridge-git-cred-store", text=True)
+        cmd = [ 'git', 'config', '--global', 'credential.helper', f"store --file {self.git_store[1]}" ]
+        self.run_cmd(cmd, fatal="git config credential.helper")
+
+        with open(cred_file, "r", encoding="utf-8") as cred:
+            for line in cred.readlines():
+                line = line.rstrip()
+                entry = line.split(' ')
+                if len(entry) != 4:
+                    continue
+
+                project = str(os.getenv('OBS_SERVICE_PROJECT'))
+                if entry[0] != '*' and not project.startswith(entry[0]):
+                    continue
+
+                cmd = [ 'git', 'credential-store', '--file', self.git_store[1], 'store' ]
+                proc = subprocess.Popen(cmd, shell=False, encoding="utf-8", stdin=subprocess.PIPE)
+                text=f"protocol=https\nhost={entry[1]}\nusername={entry[2]}\npassword={entry[3]}\n"
+                proc.communicate(input=text)
+                if proc.returncode != 0:
+                    self.die("could not setup git credential store")
+
+    def run_cmd_nonfatal(self, cmd: List[str], *, cwd: Optional[str]=None, stdout: Union[int, TextIO]=subprocess.PIPE, env: Optional[Dict[str, str]]=None) -> Tuple[int, str]:
+        logging.debug("COMMAND: %s" % cmd)
+        stderr = subprocess.PIPE
+        if stdout == subprocess.PIPE:
+            stderr = subprocess.STDOUT
+        proc = subprocess.Popen(cmd, shell=False, stdout=stdout, stderr=stderr, cwd=cwd, env=env)
+        std_out = proc.communicate()[0]
+        output = std_out.decode() if std_out else ''
+
+        logging.debug("RESULT(%d): %s", proc.returncode, repr(output))
+        return (proc.returncode, output)
+
+    def run_cmd(self, cmd: List[str], *, fatal: str, cwd: Optional[str]=None, stdout: Union[int, TextIO]=subprocess.PIPE, env: Optional[Dict[str, str]]=None) -> str:
+        returncode, output = self.run_cmd_nonfatal(cmd, cwd=cwd, stdout=stdout, env=env)
+        if returncode != 0:
+            print("ERROR: " + fatal + " failed: ", output)
+            transient_error = False
+            for name in self.critical_git_servers:
+                if output.find("Failed to connect to " + name) >= 0:
+                    transient_error = True
+                if output.find("unable to access") >= 0 and output.find(name) >= 0:
+                    transient_error = True
+            if transient_error:
+                print("TRANSIENT ERROR: " + fatal + " failed")
+            sys.exit(1)
+        return output
+
+    def verify_branch(self, branch:str) -> None:
+        if branch.startswith('-'):
+            self.die(f"illegal branch/commit '{branch}'")
+            sys.exit(1)
+
+    def verify_subdir(self, subdir:str) -> None:
+        if subdir.startswith('-'):
+            self.die(f"illegal sub-directory '{subdir}'")
+
+    def verify_scmurl(self, scmurl:str) -> None:
+        if testcase_mode and scmurl.startswith('file://'):
+            return
+        if not(scmurl.startswith('http://') or scmurl.startswith('https://') or scmurl.startswith('ssh://')):
+            self.die(f"illegal scm url '{scmurl}'")
+
+    def do_set_sparse_checkout(self, outdir: str) -> None:
+        self.run_cmd([ 'git', '-C', outdir, 'sparse-checkout', 'set', self.subdir ], fatal="git sparse-checkout")
+
+    def do_checkout(self, outdir: str, branch: str, include_submodules: bool=False) -> None:
+        self.verify_branch(branch)
+        env = {"GIT_LFS_SKIP_SMUDGE": "1", **os.environ} if self.no_lfs else None
+        cmd = [ 'git', '-C', outdir, 'checkout', '-q', branch]
+        self.run_cmd(cmd, fatal="git checkout", env=env)
+        if include_submodules:
+            cmd = [ 'git', '-C', outdir, 'submodule', 'init' ]
+            self.run_cmd(cmd, fatal="git submodule init", env=env)
+            cmd = [ 'git', '-C', outdir, 'submodule', 'update', '--recursive' ]
+            if self.subdir:
+                self.verify_subdir(self.subdir)
+                cmd += [ self.subdir ]
+            self.run_cmd(cmd, fatal="git submodule update", env=env)
+
+    def do_clone_commit(self, outdir: str, include_submodules: bool=False) -> None:
+        assert self.revision, "no revision is set but do_clone_commit was called"
+        objectformat='--object-format=sha1'
+        if len(self.revision) == 64:
+            objectformat='--object-format=sha256'
+        else:
+            cmd = [ 'git', 'ls-remote', self.scmtoolurl, 'HEAD' ]
+            output = self.run_cmd(cmd, fatal="git ls-remote")
+            lastline = output.splitlines()[-1]
+            if len(lastline.rstrip()) == 69:
+                objectformat='--object-format=sha256'
+        cmd = [ 'git', 'init', objectformat, outdir ]
+        self.run_cmd(cmd, fatal="git init")
+        cmd = [ 'git', '-C', outdir, 'remote', 'add', 'origin', self.scmtoolurl ]
+        self.run_cmd(cmd, fatal="git remote add origin")
+        cmd = [ 'git', '-C', outdir, 'fetch', 'origin', self.revision ]
+        if self.shallow_clone:
+            cmd += [ '--depth', '1' ]
+        if self.subdir:
+            cmd += [ '--filter=blob:none' ]
+        if include_submodules:
+            cmd += [ '--recurse-submodules' ]
+        (returncode, output) = self.run_cmd_nonfatal(cmd)
+        if returncode != 0:
+            cmd = [ 'git', '-C', outdir, 'fetch', 'origin' ]
+            if include_submodules:
+                cmd += [ '--recurse-submodules' ]
+            self.run_cmd(cmd, fatal="git fetch")
+        if self.subdir:
+            self.do_set_sparse_checkout(outdir)
+        self.do_checkout(outdir, self.revision, include_submodules=include_submodules)
+
+    def is_type_enabled(self, asset_type: str):
+        if not self.asset_types_filter:
+            return True
+        return asset_type in self.asset_types_filter
+
+    def do_clone(self, outdir: str, include_submodules: bool=False) -> None:
+        self.verify_scmurl(self.scmtoolurl)
+        if self.revision:
+            self.verify_branch(self.revision)
+        if self.trackingbranch:
+            self.verify_branch(self.trackingbranch)
+        if self.subdir:
+            self.verify_subdir(self.subdir)
+        branch = self.revision
+        reset_to_commit = None
+        do_shallow_clone = self.shallow_clone
+        if self.revision and re.match(r"^[0-9a-fA-F]{40,}$", self.revision):
+            if follow_tracking_branch:
+                branch = self.trackingbranch
+                reset_to_commit = self.revision
+                do_shallow_clone = False
+            else:
+                self.do_clone_commit(outdir, include_submodules=include_submodules)
+                return
+        cmd = [ 'git', 'clone', self.scmtoolurl, outdir ]
+        if include_submodules:
+            if self.subdir:
+                cmd += [ "--recurse-submodules=" + self.subdir ]
+            else:
+                cmd += [ '--recurse-submodules' ]
+        if do_shallow_clone:
+            cmd += [ '--depth', '1' ]
+        if self.subdir:
+            cmd += [ '--filter=blob:none' ]
+        if self.subdir or reset_to_commit:
+            cmd += [ '--no-checkout' ]
+        if branch:
+            cmd.insert(2, '-b')
+            cmd.insert(3, branch)
+        env = {"GIT_LFS_SKIP_SMUDGE": "1", **os.environ} if self.no_lfs else None
+        self.run_cmd(cmd, fatal="git clone", env=env)
+        if reset_to_commit:
+            cmd = [ 'git', '-C', outdir, 'reset', '--soft', reset_to_commit ]
+            self.run_cmd(cmd, fatal="git reset", env=env)
+        if self.subdir:
+            self.do_set_sparse_checkout(outdir)
+        if self.subdir or reset_to_commit:
+            self.do_checkout(outdir, 'HEAD', include_submodules=include_submodules)
+
+    def write_obsinfo(self) -> None:
+        if not self.create_obsinfo:
+            return
+        if not self.subdir:
+            cmd = [ 'git', 'rev-parse', 'HEAD' ]
+            line = self.run_cmd(cmd, cwd=self.clonedir, fatal="git rev-parse")
+            commit = line.rstrip()
+            cmd = [ 'git', 'log', '-n1', '--date=format:%Y%m%d', '--no-show-signature', '--pretty=format:%ct' ]
+            line = self.run_cmd(cmd, cwd=self.clonedir, fatal="git log")
+            tstamp = line.rstrip()
+        else:
+            cmd = [ 'git', 'log', '-n1', '--no-show-signature', '--pretty=format:%H %ct', '--end-of-options', self.subdir]
+            line = self.run_cmd(cmd, cwd=self.clonedir, fatal="git log")
+            commit, tstamp = line.split()
+        infofile = os.path.join(self.outdir, '_scmsync.obsinfo')
+        if os.path.lexists(infofile):
+            self.die("the _scmsync.obsinfo file must not be part of the git repository")
+        with open(infofile, 'x') as obsinfo:
+            obsinfo.write("mtime: " + tstamp + "\n")
+            obsinfo.write("commit: " + commit + "\n")
+            if self.scmtoolurl:
+                obsinfo.write("url: " + self.scmtoolurl + "\n")
+            if self.revision:
+                obsinfo.write("revision: " + self.revision + "\n")
+            if self.trackingbranch:
+                obsinfo.write("trackingbranch: " + self.trackingbranch + "\n")
+            if self.subdir:
+                obsinfo.write("subdir: " + self.subdir + "\n")
+            if self.projectscmsync:
+                obsinfo.write("projectscmsync: " + self.projectscmsync + "\n")
+
+    def check_subdir(self, subdir: str):
+        fromdir = os.path.join(self.clonedir, subdir)
+        if not os.path.realpath(fromdir+'/').startswith(os.path.realpath(self.clonedir+'/')):
+            self.die(f"subdir {subdir} is not below clone directory")
+        if not os.path.isdir(fromdir):
+            self.die(f"subdir {subdir} does not exist")
+
+    def clone(self, include_submodules: bool=False, no_local_link: bool=False, write_service_info: bool=False) -> None:
+        if not self.subdir:
+            self.clonedir = self.outdir
+            self.do_clone(self.outdir, include_submodules=include_submodules)
+            self.write_obsinfo()
+            if write_service_info:
+                self.write_service_info()
+            return
+        clonedir = tempfile.mkdtemp(prefix="obs-scm-bridge")
+        self.clonedir = clonedir
+        self.do_clone(clonedir, include_submodules=include_submodules)
+        self.check_subdir(self.subdir)
+
+        fromdir = os.path.join(clonedir, self.subdir)
+        if os.path.islink(fromdir):
+            if no_local_link:
+                self.die(f"local link points to another local link: {self.subdir}")
+            target = os.readlink(fromdir).rstrip('/')
+            if not target or '/' in target or target.startswith('.'):
+                self.die(f"only local links are supported: {self.subdir}")
+            self.subdir=target
+            shutil.rmtree(clonedir)
+            self.clonedir = None
+            self.clone(include_submodules=include_submodules, no_local_link=True, write_service_info=write_service_info)
+            return
+
+        if not os.path.isdir(self.outdir):
+            os.makedirs(self.outdir)
+        if write_obsinfo_with_subdir:
+            self.write_obsinfo()
+        if write_service_info:
+            self.write_service_info()
+        for name in os.listdir(fromdir):
+            if name == '_scmsync.obsinfo' or name == '_service_info':
+                self.die(f"the {name} file must not be part of the git repository")
+            shutil.move(os.path.join(fromdir, name), self.outdir)
+        shutil.rmtree(clonedir)
+        self.clonedir = None
+
+    def fetch_tags(self) -> None:
+        cmd = [ 'git', '-C', self.clonedir, 'fetch', '--tags', 'origin', '+refs/heads/*:refs/remotes/origin/*' ]
+        logging.info("fetching all tags")
+        self.run_cmd(cmd, fatal="fetch --tags")
+
+    def cpio_directory(self, directory: str) -> None:
+        logging.info("create archivefile for %s", directory)
+        cmd = [ download_assets, '--create-cpio', '--', directory ]
+        with open(directory + '.obscpio', 'x') as archivefile:
+            self.run_cmd(cmd, stdout=archivefile, fatal="cpio creation")
+
+    def cpio_specials(self, specials: List[str]) -> None:
+        if not specials:
+            return
+        logging.info("create archivefile for specials")
+        cmd = [ download_assets, '--create-cpio', '--', '.' ] + specials
+        with open('build.specials.obscpio', 'x') as archivefile:
+            self.run_cmd(cmd, stdout=archivefile, fatal="cpio creation")
+
+    def cpio_directories(self) -> None:
+        logging.debug("walk via %s", self.outdir)
+        os.chdir(self.outdir)
+        listing = sorted(os.listdir("."))
+        specials = []
+        for name in listing:
+            if name in ('.git', '.gitattributes') and not self.keep_meta:
+                continue
+            if name[0:1] == '.':
+                specials.append(name)
+                continue
+            if os.path.islink(name):
+                specials.append(name)
+                continue
+            if os.path.isfile(name) and os.access(name, os.X_OK):
+                specials.append(name)
+            if os.path.isdir(name):
+                logging.info("CPIO %s ", name)
+                self.cpio_directory(name)
+                shutil.rmtree(name)
+        if specials:
+            self.cpio_specials(specials)
+            for name in specials:
+                if os.path.isdir(name):
+                    shutil.rmtree(name)
+                else:
+                    os.unlink(name)
+
+    def get_assets(self) -> None:
+        logging.info("downloading assets")
+        cmd = [ download_assets ]
+        for arch in self.arch:
+            cmd += [ '--arch', arch ]
+        for asset_type in self.asset_types_filter:
+            cmd += [ '--type', asset_type ]
+        if pack_directories:
+            cmd += [ '--noassetdir', '--', self.outdir ]
+        else:
+            cmd += [ '--unpack', '--noassetdir', '--', self.outdir ]
+        self.run_cmd(cmd, fatal="asset download")
+
+    def copyfile(self, src: str, dst: str) -> None:
+        shutil.copy2(os.path.join(self.outdir, src), os.path.join(self.outdir, dst))
+
+    def export_debian_files(self) -> None:
+        if os.path.isfile(self.outdir + "/debian/control") and \
+                not os.path.isfile(self.outdir + "/debian.control"):
+            self.copyfile("debian/control", "debian.control")
+        if os.path.isfile(self.outdir + "/debian/changelog") and \
+                not os.path.isfile(self.outdir + "/debian.changelog"):
+            self.copyfile("debian/changelog", "debian.changelog")
+
+    def get_debian_origtar(self) -> None:
+        if os.path.isfile(self.outdir + "/debian/control"):
+            if not self.subdir:
+                self.fetch_tags()
+            cmd = [ export_debian_orig_from_git, self.outdir ]
+            logging.info("exporting debian origtar")
+            self.run_cmd(cmd, fatal="debian origtar export")
+
+    def get_subdir_info(self, path: str) -> str:
+        cmd = [ 'git', '-C', self.clonedir, 'ls-tree', '-d', 'HEAD', '--end-of-options', path ]
+        output = self.run_cmd(cmd, fatal="git ls-tree")
+        for line in output.splitlines():
+            lstree = line.split(maxsplit=4)
+            if len(lstree[2]) >= 40:
+                return lstree[2]
+        self.die(f"could not determine tree info of {path}")
+
+    def write_info_file(self, filename: str, info: str) -> None:
+        if not filename.startswith("/"):
+            filename = self.outdir + "/" + filename
+        if os.path.lexists(filename):
+            self.die(f"the {filename} file must not be part of the git repository")
+        with open(filename, 'x') as infofile:
+            infofile.write(info + '\n')
+
+    def write_service_info(self) -> None:
+        info = None
+        if self.subdir:
+            info = self.get_subdir_info(self.subdir)
+        else:
+            cmd = [ 'git', '-C', self.clonedir, 'rev-parse', 'HEAD' ]
+            info = self.run_cmd(cmd, fatal="git rev-parse HEAD")
+            info = info.strip()
+        if info:
+            self.write_info_file(os.path.join(self.outdir, "_service_info"), info)
+
+    def write_package_xml_file(self, name: str, url: str, projectscmsync: str=None) -> None:
+        if self.onlybuild and name not in self.onlybuild.keys():
+            return
+        filename = f"{self.outdir}/{name}.xml"
+        with open(filename, 'x') as xmlfile:
+            xmlfile.write(f"""<package name="{escape(name)}">\n""")
+            if self.enforce_bcntsynctag:
+                xmlfile.write(f"""<bcntsynctag>{escape(name)}</bcntsynctag>\n""")
+            if projectscmsync:
+                xmlfile.write(f"""<url>{escape(projectscmsync)}</url>\n""")
+            xmlfile.write(f"""<scmsync>{escape(url)}</scmsync>\n</package>\n""")
+
+    def write_package_xml_local_link(self, name: str, target: str, projectscmsync: str=None) -> None:
+        if self.onlybuild and not name in self.onlybuild.keys():
+            return
+        filename = f"{self.outdir}/{name}.xml"
+        with open(filename, 'x') as xmlfile:
+            xmlfile.write(f"""<package name="{escape(name)}">""")
+            if self.enforce_bcntsynctag:
+                xmlfile.write(f"""<bcntsynctag>{escape(name)}</bcntsynctag>""")
+            if projectscmsync:
+                xmlfile.write(f"""<url>{escape(projectscmsync)}</url>\n""")
+            xmlfile.write("""</package>""")
+        filename = f"{self.outdir}/{name}.link"
+        with open(filename, 'x') as linkfile:
+            linkfile.write(f"""<link package="{escape(target)}" cicount="copy" />""")
+
+    def list_submodule_revisions(self, subdir: str) -> Dict[str, str]:
+        revisions = {}
+        cmd = [ 'git', '-C', self.clonedir, 'ls-tree', 'HEAD', '--end-of-options', (subdir if subdir else '.') ]
+        output = self.run_cmd(cmd, fatal="git ls-tree")
+        for line in output.splitlines():
+            lstree = line.split(maxsplit=4)
+            if lstree[1] == 'commit' and len(lstree[2]) >= 40:
+                revisions[lstree[3]] = lstree[2]
+        return revisions
+
+    def process_package_submodule(self, name: str, subdir: str) -> None:
+        if not self._REGEXP.match(name):
+            logging.warn("submodule name contains invalid char: %s", name)
+            return
+
+        section = self.gsmpath[subdir + name]
+        if not section:
+            logging.warn("submodule not configured for %s", subdir + name)
+            return
+        gsmsection = self.gsmconfig[section]
+
+        urlstr = gsmsection['url']
+        if not urlstr:
+            self.die(f"url not defined for submodule {section}")
+
+        revisions = self.gsmrevisions.get(subdir)
+        if not revisions:
+            revisions = self.gsmrevisions[subdir] = self.list_submodule_revisions(subdir)
+
+        revision = revisions.get(gsmsection['path'])
+        if not revision:
+            self.die(f"could not determine revision of submodule for {gsmsection['path']}")
+
+        url = list(urllib.parse.urlparse(urlstr))
+        url[5] = revision
+        if 'branch' in gsmsection:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['trackingbranch'] = [gsmsection['branch']]
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.arch:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['arch'] = self.arch
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.asset_types_filter:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['buildtype'] = self.asset_types_filter
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.add_noobsinfo:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['noobsinfo'] = [ '1' ]
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+
+        unparsed_url = urllib.parse.urlunparse(url)
+        if ".." == unparsed_url[0:2]:
+            unparsed_url = urllib.parse.urljoin(self.scmtoolurl+'/', unparsed_url)
+        if self.url[0][0:4] == 'git+':
+            unparsed_url = 'git+' + unparsed_url
+
+        projectscmsync = urllib.parse.urlunparse(self.url)
+
+        self.write_package_xml_file(name, unparsed_url, projectscmsync)
+        self.write_info_file(name + ".info", revision)
+
+    def process_package_subdirectory(self, name: str, subdir: str) -> None:
+        if not self._REGEXP.match(name):
+            logging.warn("directory name contains invalid char: %s", name)
+            return
+
+        info = self.get_subdir_info(subdir + name)
+        self.write_info_file(name + ".info", info)
+
+        url = self.url.copy()
+        query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+        query['subdir'] = subdir + name
+        url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.revision:
+            url[5] = self.revision
+        if self.arch:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['arch'] = self.arch
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.asset_types_filter:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['buildtype'] = self.asset_types_filter
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.add_noobsinfo:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['noobsinfo'] = 1
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+
+        self.write_package_xml_file(name, urllib.parse.urlunparse(url))
+
+    def process_package_locallink(self, name: str, target: str) -> None:
+        if not self._REGEXP.match(name):
+            logging.warn("locallink name contains invalid char: %s", name)
+            return
+        if not self._REGEXP.match(target):
+            logging.warn("locallink target contains invalid char: %s", target)
+            return
+        self.write_package_xml_local_link(name, target)
+
+    def parse_gsmconfig(self):
+        self.gsmconfig = configparser.ConfigParser()
+
+        gitmodules = None
+        with open(self.clonedir + '/.gitmodules') as f:
+            gitmodules = f.read()
+        gitmodules = "\n".join([line.lstrip() for line in gitmodules.split("\n")])
+
+        self.gsmconfig.read_string(gitmodules)
+        gsmpath = {}
+        for section in self.gsmconfig.sections():
+            gsmconfig = self.gsmconfig[section]
+            if 'path' not in gsmconfig:
+                logging.warn("path not defined for git submodule " + section)
+                continue
+            path = gsmconfig['path']
+            if path in gsmpath:
+                logging.warn("multiple definitions of %s path in git submodule config", path)
+                continue
+            gsmpath[path] = section
+        self.gsmpath = gsmpath
+
+    def generate_project_files(self) -> None:
+        clonedir = tempfile.mkdtemp(prefix="obs-scm-bridge")
+        self.clonedir = clonedir
+        self.do_clone(clonedir)
+        if self.subdir:
+            self.check_subdir(self.subdir)
+        if not os.path.isdir(self.outdir):
+            os.makedirs(self.outdir)
+        if not self.subdir or write_obsinfo_with_subdir:
+            self.write_obsinfo()
+        os.chdir(self.outdir)
+        subdir = self.subdir + '/' if self.subdir else ''
+        if os.path.isfile(clonedir + '/.gitmodules'):
+            self.parse_gsmconfig()
+        self.generate_package_xml_files_of_directory(subdir)
+        shutil.rmtree(clonedir)
+        self.clonedir = None
+
+    def generate_package_xml_files_of_directory(self, subdir) -> None:
+        if subdir:
+            self.verify_subdir(subdir)
+            self.check_subdir(subdir)
+        directory = (self.clonedir + '/' + subdir).rstrip('/')
+        logging.debug("check %s (subdir=%s)", directory, subdir)
+
+        if os.path.isfile(directory + '/_config'):
+            shutil.move(directory + '/_config', '.')
+            self.processed['_config'] = True
+
+        packages = None
+        subdirectories = []
+
+        if os.path.isfile(directory + '/_manifest'):
+            (packages, subdirectories) = read_project_manifest(directory + '/_manifest')
+        elif os.path.isfile(directory + '/_subdirs'):
+            (packages, subdirectories) = read_project_subdirs(directory + '/_subdirs')
+
+        for newsubdir in subdirectories:
+            if (subdir + newsubdir + '/') in self.processed:
+                continue
+            self.processed[subdir + newsubdir + '/'] = True
+            self.generate_package_xml_files_of_directory(subdir + newsubdir + '/')
+
+        if packages is None:
+            logging.debug("walk via %s", directory)
+            packages = sorted(os.listdir(directory))
+
+        for name in packages:
+            if name in self.processed:
+                continue
+            fname = directory + '/' + name
+            if name == '.git':
+                if self.keep_meta and subdir == '':
+                    shutil.move(fname, '.')
+                    self.processed[name] = True
+            elif os.path.islink(fname):
+                target = os.readlink(fname).rstrip('/')
+                if not target or '/' in target or target.startswith('.'):
+                    logging.warn("only local links are supported, skipping: %s -> %s", name, target)
+                    continue
+                if not os.path.isdir(directory + '/' + target):
+                    logging.debug("skipping dangling symlink %s -> %s", name, target)
+                    continue
+                self.process_package_locallink(name, target)
+                self.processed[name] = True
+            elif os.path.isdir(fname):
+                if (subdir + name + '/') in self.processed:
+                    continue
+                if (subdir + name) in self.gsmpath:
+                    self.process_package_submodule(name, subdir)
+                else:
+                    self.process_package_subdirectory(name, subdir)
+                self.processed[name] = True
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(
+        description='Open Build Service source service for managing packaging files in git.'
+        'This is a special service for OBS git integration.')
+    parser.add_argument('--outdir', required=True,
+                        help='output directory for modified sources',
+                        nargs=1,
+                        type=str)
+    parser.add_argument('--url',
+                        help='REQUIRED: url to git repository',
+                        required=True,
+                        nargs=1,
+                        type=str)
+    parser.add_argument('--projectmode',
+                        help='just return the package list based on the subdirectories')
+    parser.add_argument('--projectscmsync',
+                        help='add also reference information of a project git for a package clone')
+    parser.add_argument('--debug',
+                        help='verbose debug mode')
+    args = vars(parser.parse_args())
+
+    url = args['url'][0]
+    outdir = args['outdir'][0]
+    project_mode = args['projectmode']
+    projectscmsync = args['projectscmsync']
+
+    if args['debug']:
+        logging.getLogger().setLevel(logging.DEBUG)
+        logging.debug("Running in debug mode")
+
+    obsgit = ObsGit(outdir, url, projectscmsync)
+    obsgit.add_critical_instance("src.opensuse.org")
+    if os.path.isfile(critical_instances_config):
+        with open(critical_instances_config) as conf:
+            for line in conf.readlines():
+                obsgit.add_critical_instance(line.rstrip())
+    if os.path.isfile(credentials_config):
+        obsgit.setup_credentials(credentials_config)
+
+    if project_mode == 'true' or project_mode == '1':
+        obsgit.generate_project_files()
+        sys.exit(0)
+
+    obsgit.clone(include_submodules=True, write_service_info=pack_directories)
+
+    if get_assets:
+        obsgit.get_assets()
+        if obsgit.is_type_enabled('dsc'):
+            obsgit.get_debian_origtar()
+    if pack_directories:
+        if obsgit.is_type_enabled('dsc'):
+            obsgit.export_debian_files()
+        obsgit.cpio_directories()

--- a/obs_scm_bridge/git.py
+++ b/obs_scm_bridge/git.py
@@ -1,0 +1,712 @@
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from html import escape
+from typing import Dict, List, Optional, TextIO, Tuple, Union
+import urllib.parse
+import configparser
+
+from obs_scm_bridge.manifest import read_project_manifest, read_project_subdirs
+
+
+download_assets = '/usr/lib/build/download_assets'
+critical_instances_config = "/etc/obs/services/scm-bridge/critical-instances"
+credentials_config = "/etc/obs/services/scm-bridge/credentials"
+export_debian_orig_from_git = '/usr/lib/build/export_debian_orig_from_git'
+pack_directories = False
+follow_tracking_branch = False
+get_assets = False
+shallow_clone = True
+create_obsinfo = False
+rewrite_url_to_ssh = False
+write_obsinfo_with_subdir = True
+testcase_mode = False
+
+if os.environ.get('DEBUG_SCM_BRIDGE') == "1":
+    logging.getLogger().setLevel(logging.DEBUG)
+if os.environ.get('SCM_BRIDGE_TESTCASE') == "1":
+    testcase_mode = True
+if os.environ.get('OBS_SERVICE_DAEMON'):
+    pack_directories = True
+    get_assets = True
+    create_obsinfo = True
+if os.environ.get('OSC_VERSION'):
+    get_assets = True
+    shallow_clone = False
+    create_obsinfo = False
+    rewrite_url_to_ssh = True
+    follow_tracking_branch = True
+os.environ['LANG'] = "C"
+
+
+class ObsGit(object):
+
+    _REGEXP = re.compile(r"^[a-zA-Z0-9\-\_\+][a-zA-Z0-9\.\-\_\+]*$")
+
+    def __init__(self, outdir: str, url: str, projectscmsync: str) -> None:
+        self.outdir   = outdir
+        self.clonedir = None
+        self.revision = None
+        self.trackingbranch = None
+        self.subdir   = None
+        self.projectscmsync = projectscmsync
+        self.keep_meta = False
+        self.arch = []
+        self.critical_git_servers = []
+        self.onlybuild = None
+        self.url = list(urllib.parse.urlparse(url))
+        self.no_lfs = False
+        self.enforce_bcntsynctag = False
+        self.processed = {}
+        self.git_store = None
+        self.shallow_clone = shallow_clone
+        self.create_obsinfo = create_obsinfo
+        self.add_noobsinfo = False
+        self.gsmconfig: Optional[configparser.ConfigParser] = None
+        self.gsmpath = {}
+        self.gsmrevisions = {}
+        self.asset_types_filter = []
+
+        query = urllib.parse.parse_qs(self.url[4], keep_blank_values=True)
+        if "subdir" in query:
+            self.subdir = query['subdir'][0]
+            del query['subdir']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "arch" in query:
+            self.arch = query['arch']
+            del query['arch']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "enforce_bcntsynctag" in query:
+            self.enforce_bcntsynctag = True
+            del query['enforce_bcntsynctag']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "keepmeta" in query:
+            self.keep_meta = True
+            del query['keepmeta']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "lfs" in query:
+            self.no_lfs = query["lfs"] == ["0"]
+            del query["lfs"]
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "onlybuild" in query:
+            ob = query['onlybuild']
+            self.onlybuild={ob[i]:1 for i in range(len(ob))}
+            del query['onlybuild']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "noobsinfo" in query:
+            self.add_noobsinfo = True
+            self.create_obsinfo = False
+            del query['noobsinfo']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if 'trackingbranch' in query:
+            self.trackingbranch = query['trackingbranch'][0]
+            del query['trackingbranch']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if "buildtype" in query:
+            t = query['buildtype']
+            self.asset_types_filter=[t[i] for i in range(len(t))]
+            del query['buildtype']
+            self.url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.url[5]:
+            self.revision = self.url[5]
+            self.url[5] = ''
+        if self.subdir:
+            self.shallow_clone = True
+            if self.create_obsinfo and write_obsinfo_with_subdir:
+                self.shallow_clone = False
+            self.keep_meta = False
+        if self.keep_meta:
+            self.shallow_clone = False
+        scmtoolurl = self.url.copy()
+        if scmtoolurl[0] and scmtoolurl[0][0:4] == 'git+':
+            scmtoolurl[0] = scmtoolurl[0][4:]
+        if rewrite_url_to_ssh and scmtoolurl[0] == 'https':
+            if scmtoolurl[1] == 'src.suse.de':
+                scmtoolurl[1] = 'gitea@src.suse.de'
+                scmtoolurl[0] = 'ssh'
+            elif scmtoolurl[1] == 'src.opensuse.org':
+                scmtoolurl[1] = 'gitea@src.opensuse.org'
+                scmtoolurl[0] = 'ssh'
+        self.scmtoolurl = urllib.parse.urlunparse(scmtoolurl)
+
+    def die(self, msg:str):
+        logging.error(msg)
+        sys.exit(1)
+
+    def add_critical_instance(self, name: str) -> None:
+        self.critical_git_servers.append(name)
+
+    def setup_credentials(self, cred_file: str) -> None:
+        self.git_store = tempfile.mkstemp(prefix="obs-scm-bridge-git-cred-store", text=True)
+        cmd = [ 'git', 'config', '--global', 'credential.helper', f"store --file {self.git_store[1]}" ]
+        self.run_cmd(cmd, fatal="git config credential.helper")
+
+        with open(cred_file, "r", encoding="utf-8") as cred:
+            for line in cred.readlines():
+                line = line.rstrip()
+                entry = line.split(' ')
+                if len(entry) != 4:
+                    continue
+
+                project = str(os.getenv('OBS_SERVICE_PROJECT'))
+                if entry[0] != '*' and not project.startswith(entry[0]):
+                    continue
+
+                cmd = [ 'git', 'credential-store', '--file', self.git_store[1], 'store' ]
+                proc = subprocess.Popen(cmd, shell=False, encoding="utf-8", stdin=subprocess.PIPE)
+                text=f"protocol=https\nhost={entry[1]}\nusername={entry[2]}\npassword={entry[3]}\n"
+                proc.communicate(input=text)
+                if proc.returncode != 0:
+                    self.die("could not setup git credential store")
+
+    def run_cmd_nonfatal(self, cmd: List[str], *, cwd: Optional[str]=None, stdout: Union[int, TextIO]=subprocess.PIPE, env: Optional[Dict[str, str]]=None) -> Tuple[int, str]:
+        logging.debug("COMMAND: %s" % cmd)
+        stderr = subprocess.PIPE
+        if stdout == subprocess.PIPE:
+            stderr = subprocess.STDOUT
+        proc = subprocess.Popen(cmd, shell=False, stdout=stdout, stderr=stderr, cwd=cwd, env=env)
+        std_out = proc.communicate()[0]
+        output = std_out.decode() if std_out else ''
+
+        logging.debug("RESULT(%d): %s", proc.returncode, repr(output))
+        return (proc.returncode, output)
+
+    def run_cmd(self, cmd: List[str], *, fatal: str, cwd: Optional[str]=None, stdout: Union[int, TextIO]=subprocess.PIPE, env: Optional[Dict[str, str]]=None) -> str:
+        returncode, output = self.run_cmd_nonfatal(cmd, cwd=cwd, stdout=stdout, env=env)
+        if returncode != 0:
+            print("ERROR: " + fatal + " failed: ", output)
+            transient_error = False
+            for name in self.critical_git_servers:
+                if output.find("Failed to connect to " + name) >= 0:
+                    transient_error = True
+                if output.find("unable to access") >= 0 and output.find(name) >= 0:
+                    transient_error = True
+            if transient_error:
+                print("TRANSIENT ERROR: " + fatal + " failed")
+            sys.exit(1)
+        return output
+
+    def verify_branch(self, branch:str) -> None:
+        if branch.startswith('-'):
+            self.die(f"illegal branch/commit '{branch}'")
+            sys.exit(1)
+
+    def verify_subdir(self, subdir:str) -> None:
+        if subdir.startswith('-'):
+            self.die(f"illegal sub-directory '{subdir}'")
+
+    def verify_scmurl(self, scmurl:str) -> None:
+        if testcase_mode and scmurl.startswith('file://'):
+            return
+        if not(scmurl.startswith('http://') or scmurl.startswith('https://') or scmurl.startswith('ssh://')):
+            self.die(f"illegal scm url '{scmurl}'")
+
+    def do_set_sparse_checkout(self, outdir: str) -> None:
+        self.run_cmd([ 'git', '-C', outdir, 'sparse-checkout', 'set', self.subdir ], fatal="git sparse-checkout")
+
+    def do_checkout(self, outdir: str, branch: str, include_submodules: bool=False) -> None:
+        self.verify_branch(branch)
+        env = {"GIT_LFS_SKIP_SMUDGE": "1", **os.environ} if self.no_lfs else None
+        cmd = [ 'git', '-C', outdir, 'checkout', '-q', branch]
+        self.run_cmd(cmd, fatal="git checkout", env=env)
+        if include_submodules:
+            cmd = [ 'git', '-C', outdir, 'submodule', 'init' ]
+            self.run_cmd(cmd, fatal="git submodule init", env=env)
+            cmd = [ 'git', '-C', outdir, 'submodule', 'update', '--recursive' ]
+            if self.subdir:
+                self.verify_subdir(self.subdir)
+                cmd += [ self.subdir ]
+            self.run_cmd(cmd, fatal="git submodule update", env=env)
+
+    def do_clone_commit(self, outdir: str, include_submodules: bool=False) -> None:
+        assert self.revision, "no revision is set but do_clone_commit was called"
+        objectformat='--object-format=sha1'
+        if len(self.revision) == 64:
+            objectformat='--object-format=sha256'
+        else:
+            cmd = [ 'git', 'ls-remote', self.scmtoolurl, 'HEAD' ]
+            output = self.run_cmd(cmd, fatal="git ls-remote")
+            lastline = output.splitlines()[-1]
+            if len(lastline.rstrip()) == 69:
+                objectformat='--object-format=sha256'
+        cmd = [ 'git', 'init', objectformat, outdir ]
+        self.run_cmd(cmd, fatal="git init")
+        cmd = [ 'git', '-C', outdir, 'remote', 'add', 'origin', self.scmtoolurl ]
+        self.run_cmd(cmd, fatal="git remote add origin")
+        cmd = [ 'git', '-C', outdir, 'fetch', 'origin', self.revision ]
+        if self.shallow_clone:
+            cmd += [ '--depth', '1' ]
+        if self.subdir:
+            cmd += [ '--filter=blob:none' ]
+        if include_submodules:
+            cmd += [ '--recurse-submodules' ]
+        (returncode, output) = self.run_cmd_nonfatal(cmd)
+        if returncode != 0:
+            cmd = [ 'git', '-C', outdir, 'fetch', 'origin' ]
+            if include_submodules:
+                cmd += [ '--recurse-submodules' ]
+            self.run_cmd(cmd, fatal="git fetch")
+        if self.subdir:
+            self.do_set_sparse_checkout(outdir)
+        self.do_checkout(outdir, self.revision, include_submodules=include_submodules)
+
+    def is_type_enabled(self, asset_type: str):
+        if not self.asset_types_filter:
+            return True
+        return asset_type in self.asset_types_filter
+
+    def do_clone(self, outdir: str, include_submodules: bool=False) -> None:
+        self.verify_scmurl(self.scmtoolurl)
+        if self.revision:
+            self.verify_branch(self.revision)
+        if self.trackingbranch:
+            self.verify_branch(self.trackingbranch)
+        if self.subdir:
+            self.verify_subdir(self.subdir)
+        branch = self.revision
+        reset_to_commit = None
+        do_shallow_clone = self.shallow_clone
+        if self.revision and re.match(r"^[0-9a-fA-F]{40,}$", self.revision):
+            if follow_tracking_branch:
+                branch = self.trackingbranch
+                reset_to_commit = self.revision
+                do_shallow_clone = False
+            else:
+                self.do_clone_commit(outdir, include_submodules=include_submodules)
+                return
+        cmd = [ 'git', 'clone', self.scmtoolurl, outdir ]
+        if include_submodules:
+            if self.subdir:
+                cmd += [ "--recurse-submodules=" + self.subdir ]
+            else:
+                cmd += [ '--recurse-submodules' ]
+        if do_shallow_clone:
+            cmd += [ '--depth', '1' ]
+        if self.subdir:
+            cmd += [ '--filter=blob:none' ]
+        if self.subdir or reset_to_commit:
+            cmd += [ '--no-checkout' ]
+        if branch:
+            cmd.insert(2, '-b')
+            cmd.insert(3, branch)
+        env = {"GIT_LFS_SKIP_SMUDGE": "1", **os.environ} if self.no_lfs else None
+        self.run_cmd(cmd, fatal="git clone", env=env)
+        if reset_to_commit:
+            cmd = [ 'git', '-C', outdir, 'reset', '--soft', reset_to_commit ]
+            self.run_cmd(cmd, fatal="git reset", env=env)
+        if self.subdir:
+            self.do_set_sparse_checkout(outdir)
+        if self.subdir or reset_to_commit:
+            self.do_checkout(outdir, 'HEAD', include_submodules=include_submodules)
+
+    def write_obsinfo(self) -> None:
+        if not self.create_obsinfo:
+            return
+        if not self.subdir:
+            cmd = [ 'git', 'rev-parse', 'HEAD' ]
+            line = self.run_cmd(cmd, cwd=self.clonedir, fatal="git rev-parse")
+            commit = line.rstrip()
+            cmd = [ 'git', 'log', '-n1', '--date=format:%Y%m%d', '--no-show-signature', '--pretty=format:%ct' ]
+            line = self.run_cmd(cmd, cwd=self.clonedir, fatal="git log")
+            tstamp = line.rstrip()
+        else:
+            cmd = [ 'git', 'log', '-n1', '--no-show-signature', '--pretty=format:%H %ct', '--end-of-options', self.subdir]
+            line = self.run_cmd(cmd, cwd=self.clonedir, fatal="git log")
+            commit, tstamp = line.split()
+        infofile = os.path.join(self.outdir, '_scmsync.obsinfo')
+        if os.path.lexists(infofile):
+            self.die("the _scmsync.obsinfo file must not be part of the git repository")
+        with open(infofile, 'x') as obsinfo:
+            obsinfo.write("mtime: " + tstamp + "\n")
+            obsinfo.write("commit: " + commit + "\n")
+            if self.scmtoolurl:
+                obsinfo.write("url: " + self.scmtoolurl + "\n")
+            if self.revision:
+                obsinfo.write("revision: " + self.revision + "\n")
+            if self.trackingbranch:
+                obsinfo.write("trackingbranch: " + self.trackingbranch + "\n")
+            if self.subdir:
+                obsinfo.write("subdir: " + self.subdir + "\n")
+            if self.projectscmsync:
+                obsinfo.write("projectscmsync: " + self.projectscmsync + "\n")
+
+    def check_subdir(self, subdir: str):
+        fromdir = os.path.join(self.clonedir, subdir)
+        if not os.path.realpath(fromdir+'/').startswith(os.path.realpath(self.clonedir+'/')):
+            self.die(f"subdir {subdir} is not below clone directory")
+        if not os.path.isdir(fromdir):
+            self.die(f"subdir {subdir} does not exist")
+
+    def clone(self, include_submodules: bool=False, no_local_link: bool=False, write_service_info: bool=False) -> None:
+        if not self.subdir:
+            self.clonedir = self.outdir
+            self.do_clone(self.outdir, include_submodules=include_submodules)
+            self.write_obsinfo()
+            if write_service_info:
+                self.write_service_info()
+            return
+        clonedir = tempfile.mkdtemp(prefix="obs-scm-bridge")
+        self.clonedir = clonedir
+        self.do_clone(clonedir, include_submodules=include_submodules)
+        self.check_subdir(self.subdir)
+
+        fromdir = os.path.join(clonedir, self.subdir)
+        if os.path.islink(fromdir):
+            if no_local_link:
+                self.die(f"local link points to another local link: {self.subdir}")
+            target = os.readlink(fromdir).rstrip('/')
+            if not target or '/' in target or target.startswith('.'):
+                self.die(f"only local links are supported: {self.subdir}")
+            self.subdir=target
+            shutil.rmtree(clonedir)
+            self.clonedir = None
+            self.clone(include_submodules=include_submodules, no_local_link=True, write_service_info=write_service_info)
+            return
+
+        if not os.path.isdir(self.outdir):
+            os.makedirs(self.outdir)
+        if write_obsinfo_with_subdir:
+            self.write_obsinfo()
+        if write_service_info:
+            self.write_service_info()
+        for name in os.listdir(fromdir):
+            if name == '_scmsync.obsinfo' or name == '_service_info':
+                self.die(f"the {name} file must not be part of the git repository")
+            shutil.move(os.path.join(fromdir, name), self.outdir)
+        shutil.rmtree(clonedir)
+        self.clonedir = None
+
+    def fetch_tags(self) -> None:
+        cmd = [ 'git', '-C', self.clonedir, 'fetch', '--tags', 'origin', '+refs/heads/*:refs/remotes/origin/*' ]
+        logging.info("fetching all tags")
+        self.run_cmd(cmd, fatal="fetch --tags")
+
+    def cpio_directory(self, directory: str) -> None:
+        logging.info("create archivefile for %s", directory)
+        cmd = [ download_assets, '--create-cpio', '--', directory ]
+        with open(directory + '.obscpio', 'x') as archivefile:
+            self.run_cmd(cmd, stdout=archivefile, fatal="cpio creation")
+
+    def cpio_specials(self, specials: List[str]) -> None:
+        if not specials:
+            return
+        logging.info("create archivefile for specials")
+        cmd = [ download_assets, '--create-cpio', '--', '.' ] + specials
+        with open('build.specials.obscpio', 'x') as archivefile:
+            self.run_cmd(cmd, stdout=archivefile, fatal="cpio creation")
+
+    def cpio_directories(self) -> None:
+        logging.debug("walk via %s", self.outdir)
+        os.chdir(self.outdir)
+        listing = sorted(os.listdir("."))
+        specials = []
+        for name in listing:
+            if name in ('.git', '.gitattributes') and not self.keep_meta:
+                continue
+            if name[0:1] == '.':
+                specials.append(name)
+                continue
+            if os.path.islink(name):
+                specials.append(name)
+                continue
+            if os.path.isfile(name) and os.access(name, os.X_OK):
+                specials.append(name)
+            if os.path.isdir(name):
+                logging.info("CPIO %s ", name)
+                self.cpio_directory(name)
+                shutil.rmtree(name)
+        if specials:
+            self.cpio_specials(specials)
+            for name in specials:
+                if os.path.isdir(name):
+                    shutil.rmtree(name)
+                else:
+                    os.unlink(name)
+
+    def get_assets(self) -> None:
+        logging.info("downloading assets")
+        cmd = [ download_assets ]
+        for arch in self.arch:
+            cmd += [ '--arch', arch ]
+        for asset_type in self.asset_types_filter:
+            cmd += [ '--type', asset_type ]
+        if pack_directories:
+            cmd += [ '--noassetdir', '--', self.outdir ]
+        else:
+            cmd += [ '--unpack', '--noassetdir', '--', self.outdir ]
+        self.run_cmd(cmd, fatal="asset download")
+
+    def copyfile(self, src: str, dst: str) -> None:
+        shutil.copy2(os.path.join(self.outdir, src), os.path.join(self.outdir, dst))
+
+    def export_debian_files(self) -> None:
+        if os.path.isfile(self.outdir + "/debian/control") and \
+                not os.path.isfile(self.outdir + "/debian.control"):
+            self.copyfile("debian/control", "debian.control")
+        if os.path.isfile(self.outdir + "/debian/changelog") and \
+                not os.path.isfile(self.outdir + "/debian.changelog"):
+            self.copyfile("debian/changelog", "debian.changelog")
+
+    def get_debian_origtar(self) -> None:
+        if os.path.isfile(self.outdir + "/debian/control"):
+            if not self.subdir:
+                self.fetch_tags()
+            cmd = [ export_debian_orig_from_git, self.outdir ]
+            logging.info("exporting debian origtar")
+            self.run_cmd(cmd, fatal="debian origtar export")
+
+    def get_subdir_info(self, path: str) -> str:
+        cmd = [ 'git', '-C', self.clonedir, 'ls-tree', '-d', 'HEAD', '--end-of-options', path ]
+        output = self.run_cmd(cmd, fatal="git ls-tree")
+        for line in output.splitlines():
+            lstree = line.split(maxsplit=4)
+            if len(lstree[2]) >= 40:
+                return lstree[2]
+        self.die(f"could not determine tree info of {path}")
+
+    def write_info_file(self, filename: str, info: str) -> None:
+        if not filename.startswith("/"):
+            filename = self.outdir + "/" + filename
+        if os.path.lexists(filename):
+            self.die(f"the {filename} file must not be part of the git repository")
+        with open(filename, 'x') as infofile:
+            infofile.write(info + '\n')
+
+    def write_service_info(self) -> None:
+        info = None
+        if self.subdir:
+            info = self.get_subdir_info(self.subdir)
+        else:
+            cmd = [ 'git', '-C', self.clonedir, 'rev-parse', 'HEAD' ]
+            info = self.run_cmd(cmd, fatal="git rev-parse HEAD")
+            info = info.strip()
+        if info:
+            self.write_info_file(os.path.join(self.outdir, "_service_info"), info)
+
+    def write_package_xml_file(self, name: str, url: str, projectscmsync: str=None) -> None:
+        if self.onlybuild and name not in self.onlybuild.keys():
+            return
+        filename = f"{self.outdir}/{name}.xml"
+        with open(filename, 'x') as xmlfile:
+            xmlfile.write(f"""<package name="{escape(name)}">\n""")
+            if self.enforce_bcntsynctag:
+                xmlfile.write(f"""<bcntsynctag>{escape(name)}</bcntsynctag>\n""")
+            if projectscmsync:
+                xmlfile.write(f"""<url>{escape(projectscmsync)}</url>\n""")
+            xmlfile.write(f"""<scmsync>{escape(url)}</scmsync>\n</package>\n""")
+
+    def write_package_xml_local_link(self, name: str, target: str, projectscmsync: str=None) -> None:
+        if self.onlybuild and not name in self.onlybuild.keys():
+            return
+        filename = f"{self.outdir}/{name}.xml"
+        with open(filename, 'x') as xmlfile:
+            xmlfile.write(f"""<package name="{escape(name)}">""")
+            if self.enforce_bcntsynctag:
+                xmlfile.write(f"""<bcntsynctag>{escape(name)}</bcntsynctag>""")
+            if projectscmsync:
+                xmlfile.write(f"""<url>{escape(projectscmsync)}</url>\n""")
+            xmlfile.write("""</package>""")
+        filename = f"{self.outdir}/{name}.link"
+        with open(filename, 'x') as linkfile:
+            linkfile.write(f"""<link package="{escape(target)}" cicount="copy" />""")
+
+    def list_submodule_revisions(self, subdir: str) -> Dict[str, str]:
+        revisions = {}
+        cmd = [ 'git', '-C', self.clonedir, 'ls-tree', 'HEAD', '--end-of-options', (subdir if subdir else '.') ]
+        output = self.run_cmd(cmd, fatal="git ls-tree")
+        for line in output.splitlines():
+            lstree = line.split(maxsplit=4)
+            if lstree[1] == 'commit' and len(lstree[2]) >= 40:
+                revisions[lstree[3]] = lstree[2]
+        return revisions
+
+    def process_package_submodule(self, name: str, subdir: str) -> None:
+        if not self._REGEXP.match(name):
+            logging.warn("submodule name contains invalid char: %s", name)
+            return
+
+        section = self.gsmpath[subdir + name]
+        if not section:
+            logging.warn("submodule not configured for %s", subdir + name)
+            return
+        gsmsection = self.gsmconfig[section]
+
+        urlstr = gsmsection['url']
+        if not urlstr:
+            self.die(f"url not defined for submodule {section}")
+
+        revisions = self.gsmrevisions.get(subdir)
+        if not revisions:
+            revisions = self.gsmrevisions[subdir] = self.list_submodule_revisions(subdir)
+
+        revision = revisions.get(gsmsection['path'])
+        if not revision:
+            self.die(f"could not determine revision of submodule for {gsmsection['path']}")
+
+        url = list(urllib.parse.urlparse(urlstr))
+        url[5] = revision
+        if 'branch' in gsmsection:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['trackingbranch'] = [gsmsection['branch']]
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.arch:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['arch'] = self.arch
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.asset_types_filter:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['buildtype'] = self.asset_types_filter
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.add_noobsinfo:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['noobsinfo'] = [ '1' ]
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+
+        unparsed_url = urllib.parse.urlunparse(url)
+        if ".." == unparsed_url[0:2]:
+            unparsed_url = urllib.parse.urljoin(self.scmtoolurl+'/', unparsed_url)
+        if self.url[0][0:4] == 'git+':
+            unparsed_url = 'git+' + unparsed_url
+
+        projectscmsync = urllib.parse.urlunparse(self.url)
+
+        self.write_package_xml_file(name, unparsed_url, projectscmsync)
+        self.write_info_file(name + ".info", revision)
+
+    def process_package_subdirectory(self, name: str, subdir: str) -> None:
+        if not self._REGEXP.match(name):
+            logging.warn("directory name contains invalid char: %s", name)
+            return
+
+        info = self.get_subdir_info(subdir + name)
+        self.write_info_file(name + ".info", info)
+
+        url = self.url.copy()
+        query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+        query['subdir'] = subdir + name
+        url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.revision:
+            url[5] = self.revision
+        if self.arch:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['arch'] = self.arch
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.asset_types_filter:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['buildtype'] = self.asset_types_filter
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+        if self.add_noobsinfo:
+            query = urllib.parse.parse_qs(url[4], keep_blank_values=True)
+            query['noobsinfo'] = 1
+            url[4] = urllib.parse.urlencode(query, doseq=True)
+
+        self.write_package_xml_file(name, urllib.parse.urlunparse(url))
+
+    def process_package_locallink(self, name: str, target: str) -> None:
+        if not self._REGEXP.match(name):
+            logging.warn("locallink name contains invalid char: %s", name)
+            return
+        if not self._REGEXP.match(target):
+            logging.warn("locallink target contains invalid char: %s", target)
+            return
+        self.write_package_xml_local_link(name, target)
+
+    def parse_gsmconfig(self):
+        self.gsmconfig = configparser.ConfigParser()
+
+        gitmodules = None
+        with open(self.clonedir + '/.gitmodules') as f:
+            gitmodules = f.read()
+        gitmodules = "\n".join([line.lstrip() for line in gitmodules.split("\n")])
+
+        self.gsmconfig.read_string(gitmodules)
+        gsmpath = {}
+        for section in self.gsmconfig.sections():
+            gsmconfig = self.gsmconfig[section]
+            if 'path' not in gsmconfig:
+                logging.warn("path not defined for git submodule " + section)
+                continue
+            path = gsmconfig['path']
+            if path in gsmpath:
+                logging.warn("multiple definitions of %s path in git submodule config", path)
+                continue
+            gsmpath[path] = section
+        self.gsmpath = gsmpath
+
+    def generate_project_files(self) -> None:
+        clonedir = tempfile.mkdtemp(prefix="obs-scm-bridge")
+        self.clonedir = clonedir
+        self.do_clone(clonedir)
+        if self.subdir:
+            self.check_subdir(self.subdir)
+        if not os.path.isdir(self.outdir):
+            os.makedirs(self.outdir)
+        if not self.subdir or write_obsinfo_with_subdir:
+            self.write_obsinfo()
+        os.chdir(self.outdir)
+        subdir = self.subdir + '/' if self.subdir else ''
+        if os.path.isfile(clonedir + '/.gitmodules'):
+            self.parse_gsmconfig()
+        self.generate_package_xml_files_of_directory(subdir)
+        shutil.rmtree(clonedir)
+        self.clonedir = None
+
+    def generate_package_xml_files_of_directory(self, subdir) -> None:
+        if subdir:
+            self.verify_subdir(subdir)
+            self.check_subdir(subdir)
+        directory = (self.clonedir + '/' + subdir).rstrip('/')
+        logging.debug("check %s (subdir=%s)", directory, subdir)
+
+        if os.path.isfile(directory + '/_config'):
+            shutil.move(directory + '/_config', '.')
+            self.processed['_config'] = True
+
+        packages = None
+        subdirectories = []
+
+        if os.path.isfile(directory + '/_manifest'):
+            (packages, subdirectories) = read_project_manifest(directory + '/_manifest')
+        elif os.path.isfile(directory + '/_subdirs'):
+            (packages, subdirectories) = read_project_subdirs(directory + '/_subdirs')
+
+        for newsubdir in subdirectories:
+            if (subdir + newsubdir + '/') in self.processed:
+                continue
+            self.processed[subdir + newsubdir + '/'] = True
+            self.generate_package_xml_files_of_directory(subdir + newsubdir + '/')
+
+        if packages is None:
+            logging.debug("walk via %s", directory)
+            packages = sorted(os.listdir(directory))
+
+        for name in packages:
+            if name in self.processed:
+                continue
+            fname = directory + '/' + name
+            if name == '.git':
+                if self.keep_meta and subdir == '':
+                    shutil.move(fname, '.')
+                    self.processed[name] = True
+            elif os.path.islink(fname):
+                target = os.readlink(fname).rstrip('/')
+                if not target or '/' in target or target.startswith('.'):
+                    logging.warn("only local links are supported, skipping: %s -> %s", name, target)
+                    continue
+                if not os.path.isdir(directory + '/' + target):
+                    logging.debug("skipping dangling symlink %s -> %s", name, target)
+                    continue
+                self.process_package_locallink(name, target)
+                self.processed[name] = True
+            elif os.path.isdir(fname):
+                if (subdir + name + '/') in self.processed:
+                    continue
+                if (subdir + name) in self.gsmpath:
+                    self.process_package_submodule(name, subdir)
+                else:
+                    self.process_package_subdirectory(name, subdir)
+                self.processed[name] = True

--- a/obs_scm_bridge/manifest.py
+++ b/obs_scm_bridge/manifest.py
@@ -1,0 +1,219 @@
+import logging
+import os
+import re
+import yaml
+import configparser
+from typing import Dict, List, Optional, Tuple
+
+
+def read_project_manifest(filename: str) -> Tuple[Optional[List[str]], List[str]]:
+    packages = None
+    subdirectories = []
+    manifest_yml = None
+    with open(filename) as stream:
+        manifest_yml = yaml.safe_load(stream)
+    if 'packages' in manifest_yml:
+        packages = []
+    if manifest_yml.get('packages'):
+        for name in manifest_yml['packages']:
+            if not name or name.startswith('.') or name.startswith('/'):
+                logging.warn("illegal packages entry '%s'", name)
+                continue
+            if '/' in name or '*' in name:
+                logging.warn("packages entry with '/' or '*' not implemented yet")
+                continue
+            packages.append(name)
+    if manifest_yml.get('subdirectories'):
+        for newsubdir in manifest_yml['subdirectories']:
+            if newsubdir:
+                subdirectories.append(newsubdir)
+    return packages, subdirectories
+
+### Legacy, don't use this anymore
+def read_project_subdirs(filename: str) -> Tuple[Optional[List[str]], List[str]]:
+    packages = None
+    subdirectories = []
+    subdir_yml = None
+    with open(filename) as stream:
+        subdir_yml = yaml.safe_load(stream)
+    for newsubdir in subdir_yml['subdirs']:
+        if newsubdir:
+            subdirectories.append(newsubdir)
+    if 'toplevel' not in subdir_yml or subdir_yml['toplevel'] != 'include':
+        packages = []
+    return packages, subdirectories
+
+
+_REGEXP = re.compile(r"^[a-zA-Z0-9\-\_\+][a-zA-Z0-9\.\-\_\+]*$")
+
+
+def _read_gitmodules(directory: str) -> Dict[str, Tuple[str, str]]:
+    submodule_paths = {}
+    gitmodules_path = os.path.join(directory, '.gitmodules')
+    if not os.path.isfile(gitmodules_path):
+        return submodule_paths
+    
+    gsmconfig = configparser.ConfigParser()
+    gitmodules = None
+    with open(gitmodules_path) as f:
+        gitmodules = f.read()
+    gitmodules = "\n".join([line.lstrip() for line in gitmodules.split("\n")])
+    gsmconfig.read_string(gitmodules)
+    for section in gsmconfig.sections():
+        gsm = gsmconfig[section]
+        if 'path' in gsm:
+            submodule_paths[gsm['path']] = (section, gsm.get('url', ''))
+    return submodule_paths
+
+
+def list_packages(directory: str) -> List[Tuple[str, str, Optional[str]]]:
+    results = []
+    seen = set()
+
+    if not os.path.isdir(directory):
+        return results
+
+    submodule_paths = _read_gitmodules(directory)
+
+    if os.path.isfile(directory + '/_manifest'):
+        (_packages, _subdirs) = read_project_manifest(directory + '/_manifest')
+        if _packages:
+            for pkg in _packages:
+                if not pkg or pkg.startswith('.'):
+                    logging.warn("illegal packages entry '%s'", pkg)
+                    continue
+                if pkg in seen:
+                    logging.debug("duplicate package entry '%s'", pkg)
+                    continue
+                seen.add(pkg)
+                if '/' in pkg:
+                    subdir = pkg
+                    pkg_name = pkg.rsplit('/', 1)[-1]
+                    results.append((pkg_name, subdir, None))
+                else:
+                    results.append((pkg, pkg, None))
+        if _subdirs:
+            for subdir in _subdirs:
+                if not subdir:
+                    continue
+                if subdir in seen:
+                    logging.debug("duplicate subdirectory entry '%s'", subdir)
+                    continue
+                seen.add(subdir)
+
+                subdir_path = os.path.join(directory, subdir)
+                if os.path.isdir(subdir_path):
+                    for entry in os.listdir(subdir_path):
+                        entry_path = os.path.join(subdir_path, entry)
+                        if not os.path.isdir(entry_path):
+                            continue
+                        if not _REGEXP.match(entry):
+                            continue
+                        if entry in seen:
+                            logging.debug("duplicate package entry '%s'", entry)
+                            continue
+                        seen.add(entry)
+                        full_subdir = subdir + '/' + entry
+                        submod_info = submodule_paths.get(full_subdir)
+                        submod_url = submod_info[1] if submod_info else None
+                        results.append((entry, full_subdir, submod_url))
+                else:
+                    submod_info = submodule_paths.get(subdir)
+                    submod_url = submod_info[1] if submod_info else None
+                    results.append((subdir, subdir, submod_url))
+        return results
+
+    ### legacy, might get dropped
+    if os.path.isfile(directory + '/_subdirs'):
+        (_packages, _subdirs) = read_project_subdirs(directory + '/_subdirs')
+        if _packages:
+            for pkg in _packages:
+                if not pkg or pkg.startswith('.'):
+                    logging.warn("illegal packages entry '%s'", pkg)
+                    continue
+                if pkg in seen:
+                    logging.debug("duplicate package entry '%s'", pkg)
+                    continue
+                seen.add(pkg)
+                if '/' in pkg:
+                    subdir = pkg
+                    pkg_name = pkg.rsplit('/', 1)[-1]
+                    results.append((pkg_name, subdir, None))
+                else:
+                    results.append((pkg, pkg, None))
+        if _subdirs:
+            for subdir in _subdirs:
+                if not subdir:
+                    continue
+                if subdir in seen:
+                    logging.debug("duplicate subdirectory entry '%s'", subdir)
+                    continue
+                seen.add(subdir)
+
+                subdir_path = os.path.join(directory, subdir)
+                if os.path.isdir(subdir_path):
+                    for entry in os.listdir(subdir_path):
+                        entry_path = os.path.join(subdir_path, entry)
+                        if not os.path.isdir(entry_path):
+                            continue
+                        if not _REGEXP.match(entry):
+                            continue
+                        if entry in seen:
+                            logging.debug("duplicate package entry '%s'", entry)
+                            continue
+                        seen.add(entry)
+                        full_subdir = subdir + '/' + entry
+                        submod_info = submodule_paths.get(full_subdir)
+                        submod_url = submod_info[1] if submod_info else None
+                        results.append((entry, full_subdir, submod_url))
+                else:
+                    submod_info = submodule_paths.get(subdir)
+                    submod_url = submod_info[1] if submod_info else None
+                    results.append((subdir, subdir, submod_url))
+        return results
+
+    package_names = []
+    subdirectory_names = []
+    for entry in os.listdir(directory):
+        if entry.startswith('.') or entry.startswith('/'):
+            continue
+        if not _REGEXP.match(entry):
+            continue
+        full_path = os.path.join(directory, entry)
+        if os.path.isdir(full_path):
+            subdirectory_names.append(entry)
+        elif os.path.isfile(full_path):
+            package_names.append(entry)
+
+    for pkg in package_names:
+        if pkg in seen:
+            logging.debug("duplicate package entry '%s'", pkg)
+            continue
+        seen.add(pkg)
+        results.append((pkg, pkg, None))
+    for subdir in subdirectory_names:
+        if subdir in seen:
+            logging.debug("duplicate subdirectory entry '%s'", subdir)
+            continue
+        seen.add(subdir)
+        submod_info = submodule_paths.get(subdir)
+        submod_url = submod_info[1] if submod_info else None
+        results.append((subdir, subdir, submod_url))
+
+    for submod_path in submodule_paths.keys():
+        if submod_path in seen:
+            logging.debug("duplicate submodule entry '%s'", submod_path)
+            continue
+        seen.add(submod_path)
+        submod_info = submodule_paths.get(submod_path)
+        submod_url = submod_info[1] if submod_info else None
+        results.append((submod_path, submod_path, submod_url))
+
+    validated_results = []
+    for pkg, subdir, submod in results:
+        if not pkg and not subdir:
+            logging.warn("entry has empty package_name and git_subdirectory")
+            continue
+        validated_results.append((pkg, subdir, submod))
+
+    return validated_results

--- a/obs_scm_bridge/schema/manifest_schema.json
+++ b/obs_scm_bridge/schema/manifest_schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "OBS Project Manifest",
+  "description": "Schema for _manifest file in OBS project repositories",
+  "type": "object",
+  "properties": {
+    "packages": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-zA-Z0-9\\-_\\+][a-zA-Z0-9.\\-_\\+]*$"
+      },
+      "description": "List of directories to be used as build package"
+    },
+    "subdirectories": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-zA-Z0-9\\-_\\+][a-zA-Z0-9.\\-_\\+]*$"
+      },
+      "description": "List of subdirectory paths where each subdirectory inside is considered to be a build package"
+    }
+  },
+  "additionalProperties": false
+}

--- a/test/test_manifest.py
+++ b/test/test_manifest.py
@@ -1,0 +1,101 @@
+import os
+import tempfile
+import pytest
+from obs_scm_bridge.manifest import read_project_manifest
+
+
+class TestReadProjectManifest:
+    def test_basic_manifest(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            f.write("packages:\n  - pkg1\n  - pkg2\nsubdirectories:\n  - subdir1\n")
+            f.flush()
+            try:
+                packages, subdirs = read_project_manifest(f.name)
+                assert packages == ['pkg1', 'pkg2']
+                assert subdirs == ['subdir1']
+            finally:
+                os.unlink(f.name)
+
+    def test_manifest_with_packages_only(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            f.write("packages:\n  - mypackage\n")
+            f.flush()
+            try:
+                packages, subdirs = read_project_manifest(f.name)
+                assert packages == ['mypackage']
+                assert subdirs == []
+            finally:
+                os.unlink(f.name)
+
+    def test_manifest_with_subdirs_only(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            f.write("subdirectories:\n  - dir1\n  - dir2\n")
+            f.flush()
+            try:
+                packages, subdirs = read_project_manifest(f.name)
+                assert packages == []
+                assert subdirs == ['dir1', 'dir2']
+            finally:
+                os.unlink(f.name)
+
+    def test_illegal_package_name_starts_with_dot(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            f.write("packages:\n  - .hidden\n  - valid_pkg\n")
+            f.flush()
+            try:
+                packages, subdirs = read_project_manifest(f.name)
+                assert packages == ['valid_pkg']
+            finally:
+                os.unlink(f.name)
+
+    def test_illegal_package_name_starts_with_slash(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            f.write("packages:\n  - /invalid\n  - valid_pkg\n")
+            f.flush()
+            try:
+                packages, subdirs = read_project_manifest(f.name)
+                assert packages == ['valid_pkg']
+            finally:
+                os.unlink(f.name)
+
+    def test_illegal_package_name_with_slash(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            f.write("packages:\n  - invalid/name\n  - valid_pkg\n")
+            f.flush()
+            try:
+                packages, subdirs = read_project_manifest(f.name)
+                assert packages == ['valid_pkg']
+            finally:
+                os.unlink(f.name)
+
+    def test_illegal_package_name_with_asterisk(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            f.write("packages:\n  - wildcard*\n  - valid_pkg\n")
+            f.flush()
+            try:
+                packages, subdirs = read_project_manifest(f.name)
+                assert packages == ['valid_pkg']
+            finally:
+                os.unlink(f.name)
+
+    def test_empty_manifest(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            f.write("\n")
+            f.flush()
+            try:
+                packages, subdirs = read_project_manifest(f.name)
+                assert packages is None
+                assert subdirs == []
+            finally:
+                os.unlink(f.name)
+
+    def test_no_packages_key(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yml', delete=False) as f:
+            f.write("subdirectories:\n  - dir1\n")
+            f.flush()
+            try:
+                packages, subdirs = read_project_manifest(f.name)
+                assert packages is None
+                assert subdirs == ['dir1']
+            finally:
+                os.unlink(f.name)

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -39,7 +39,7 @@ RUN set -euo pipefail; \
     cp -r {_RPMS_DIR}ring0/aaa_base .; rm -rf aaa_base/.git; \
     git add libeconf aaa_base; git commit -m "initial commit";
 
-COPY obs_scm_bridge /usr/bin/
+COPY obs_scm_bridge.py /usr/bin/obs_scm_bridge
 RUN sed -i 's,^#!/usr/bin/python3.*,#!/usr/bin/python3.11,' /usr/bin/obs_scm_bridge
 RUN chmod +x /usr/bin/obs_scm_bridge
 """


### PR DESCRIPTION
This enables to list the used packages of a given git repository. It checks .gitsubmodule and _manifest file.

We may move this to an own python module.

Example app is doing this for current factory git:

```
./examples/list_packages.py $PWD/Factory/
Found 10 entries in 'Factory/':

Package                        Subdir                         Submodule URL
--------------------------------------------------------------------------------
cockpit-subscriptions          pkgs/c/cockpit-subscriptions   https://src.opensuse.org/pool/cockpit-subscriptions
cockpit                        pkgs/c/cockpit                 https://src.opensuse.org/pool/cockpit
cockpit-repos                  pkgs/c/cockpit-repos           https://src.opensuse.org/pool/cockpit-repos
cockpit-machines               pkgs/c/cockpit-machines        https://src.opensuse.org/pool/cockpit-machines
cockpit-packages               pkgs/c/cockpit-packages        https://src.opensuse.org/pool/cockpit-packages
cockpit-tukit                  pkgs/c/cockpit-tukit           https://src.opensuse.org/pool/cockpit-tukit
cockpit-podman                 pkgs/c/cockpit-podman          https://src.opensuse.org/pool/cockpit-podman
python-orangebox               pkgs/p/python-orangebox        ../../pool/python-orangebox
rpmlint-mini                   pkgs/r/rpmlint-mini            ../../pool/rpmlint
yast2-core                     pkgs/y/yast2-core              https://src.opensuse.org/pool/yast2-core
```